### PR TITLE
Security fix for issue 39

### DIFF
--- a/src/hsm/cmd_extras.c
+++ b/src/hsm/cmd_extras.c
@@ -28,6 +28,10 @@
 #include "mbedtls/chachapoly.h"
 
 int cmd_extras() {
+    //check button (if enabled)
+    if (wait_button_pressed() == true) { 
+                return SW_SECURE_MESSAGE_EXEC_ERROR();
+        }
     if (P1(apdu) == 0xA) { //datetime operations
         if (P2(apdu) != 0x0) {
             return SW_INCORRECT_P1P2();


### PR DESCRIPTION
This security fix ensures that the extra settings, cannot be silently disabled, if button control enabled. So the button control setting cannot be silently (without button push) disabled, even if the user's PC is fully compromised.

Could be  tested with 

```
opensc-tool -s 806406000101
opensc-tool -s 806406000100 
```