### PR TITLE
Fix for multiples of 64 bytes on cmd_list_keys

### DIFF
--- a/src/hsm/cmd_list_keys.c
+++ b/src/hsm/cmd_list_keys.c
@@ -60,5 +60,9 @@ int cmd_list_keys() {
             res_APDU[res_APDU_size++] = f->fid & 0xff;
         }
     }
+    if ((apdu.rlen + 2 + 10) % 64 == 0) {     // FIX for strange behaviour with PSCS and multiple of 64
+        res_APDU[res_APDU_size++] = 0;
+	res_APDU[res_APDU_size++] = 0;
+    }
     return SW_OK();
 }


### PR DESCRIPTION
Fix for https://github.com/polhenarejos/pico-hsm/issues/38