### PR TITLE
Correctly initialize and update git submodules for IDF in autobuild.sh

### DIFF
--- a/workflows/autobuild.sh
+++ b/workflows/autobuild.sh
@@ -29,6 +29,7 @@ sudo apt install -y git wget flex bison gperf python3 python3-pip python3-venv c
 git clone --recursive https://github.com/espressif/esp-idf.git
 cd esp-idf
 git checkout tags/v5.5
+git submodule update --init --recursive
 ./install.sh esp32s3
 . ./export.sh
 cd ..


### PR DESCRIPTION
Fixing autobuild script so ESP32 binaries now built correctly

## Summary

Describe in plain language what this PR does and why.

- What problem does it solve?
**Autobuild in github actions (nightly) not building ESP32 binaries correctly due to uninitialized submodules**
- Is it a bug fix, a new feature, a cleanup/refactor…?
**CI Bug fix**


## Licensing confirmation (required)

By checking the box below, you confirm ALL of the following:

- You are the author of this contribution, or you have the right to contribute it.
- You have read `CONTRIBUTING.md`.
- You agree that this contribution may be merged, used, modified, and redistributed:
  - under the AGPLv3 Community Edition, **and**
  - under any proprietary / commercial / Enterprise editions of this project,
    now or in the future.
- You understand that submitting this PR does not create any support obligation,
  SLA, or guarantee of merge.

**I confirm the above licensing terms:**

- [x] Yes, I agree


## Anything else?

Optional: mention known limitations, follow-ups, or if this is related to an existing Issue.
