### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ Before building, ensure you have installed the toolchain for the Pico and the Pi
 
 ```
 git clone https://github.com/polhenarejos/pico-hsm
-git submodule update --init --recursive
 cd pico-hsm
+git submodule update --init --recursive
 mkdir build
 cd build
 PICO_SDK_PATH=/path/to/pico-sdk cmake .. -DPICO_BOARD=board_type -DUSB_VID=0x1234 -DUSB_PID=0x5678


### PR DESCRIPTION
## Summary

This PR corrects the sequence of commands in the build instructions within `README.md`.

* **What problem does it solve?** It moves the `git submodule update` command to occur after changing into the project directory (`cd pico-hsm`). Previously, the instructions attempted to update submodules from the parent directory, which would fail.
* **Is it a bug fix, a new feature, a cleanup/refactor…?** Bug fix (documentation logic).

## Details / Impact

Please include any relevant details:

* **Hardware / board(s) tested:** N/A (Documentation fix).
* **Firmware / commit/base version:** N/A.
* **Security impact (if any):** None.
* **Behavior changes:** Corrects the installation flow so users can successfully initialize submodules.

## Testing

How did you test this change?

* **Steps to reproduce / validate:** Verified that `git submodule update --init --recursive` requires being inside a git repository to execute correctly.
* **Expected vs actual results:** - **Actual (Old):** Command fails because it's executed in the parent directory.
* **Expected (New):** Command executes successfully within the `pico-hsm` folder.



## Licensing confirmation (required)

By checking the box below, you confirm ALL of the following:

* [x] **Yes, I agree** (You are the author, you've read `CONTRIBUTING.md`, and you agree to the AGPLv3/Commercial licensing terms).

## Anything else?

Minor fix to ensure the "Getting Started" instructions work as written.