### PR TITLE
Add card label

### DIFF
--- a/src/hsm/files.c
+++ b/src/hsm/files.c
@@ -18,7 +18,7 @@
 #include "files.h"
 
 extern const uint8_t sc_hsm_aid[];
-extern int parse_token_info(const file_t *f, int mode);
+/* extern int parse_token_info(const file_t *f, int mode); */
 extern int parse_ef_dir(const file_t *f, int mode);
 
 file_t file_entries[] = {
@@ -32,7 +32,7 @@ file_t file_entries[] = {
                .type = FILE_TYPE_WORKING_EF | FILE_DATA_FLASH | FILE_PERSISTENT, .data = NULL,
                .ef_structure = FILE_EF_TRANSPARENT, .acl = { 0 } },                                                                                                                             //EF.GDO
     /*  4 */ { .fid = 0x2f03, .parent = 5, .name = NULL,
-               .type = FILE_TYPE_WORKING_EF | FILE_DATA_FUNC, .data = (uint8_t *) parse_token_info,
+               .type = FILE_TYPE_WORKING_EF | FILE_DATA_FLASH, .data = NULL,                                                      // ToDo: Check why callback to parse_token_info will cause a crash of the pico
                .ef_structure = FILE_EF_TRANSPARENT, .acl = { 0 } },                                                                                                                                //EF.TokenInfo
     /*  5 */ { .fid = 0x5015, .parent = 0, .name = NULL, .type = FILE_TYPE_DF, .data = NULL,
                .ef_structure = 0, .acl = { 0 } },                                                                                 //DF.PKCS15

--- a/src/hsm/sc_hsm.c
+++ b/src/hsm/sc_hsm.c
@@ -52,6 +52,7 @@ static int sc_hsm_process_apdu();
 
 static void init_sc_hsm();
 static int sc_hsm_unload();
+static const char *get_card_label();
 
 extern int cmd_select();
 extern void select_file(file_t *pe);
@@ -277,6 +278,31 @@ uint16_t get_device_options() {
     return 0x0;
 }
 
+const char *get_card_label() {
+    file_t *tokeninfo = search_file(EF_TOKENINFO);
+    if (tokeninfo && (tokeninfo->type & FILE_DATA_FLASH) && tokeninfo->data != NULL && file_get_size(tokeninfo) > 0) {
+        uint16_t tag = 0x0;
+        uint8_t *tag_data = NULL, *p = NULL;
+        uint16_t tag_len = 0;
+        asn1_ctx_t ctxi;
+        asn1_ctx_init(file_get_data(tokeninfo), file_get_size(tokeninfo), &ctxi);
+        while (walk_tlv(&ctxi, &p, &tag, &tag_len, &tag_data)) {
+            if (tag == 0x5F20 && tag_len > 0) {
+                static char label_buf[256];
+                uint16_t len = tag_len < sizeof(label_buf) ? tag_len : sizeof(label_buf) - 1;
+                memcpy(label_buf, tag_data, len);
+                label_buf[len] = 0;
+                return label_buf;
+            }
+        }
+    }
+#ifdef __FOR_CI
+    return "SmartCard-HSM";
+#else
+    return "Pico-HSM";
+#endif
+}
+
 bool wait_button_pressed() {
     uint32_t val = EV_PRESS_BUTTON;
 #ifndef ENABLE_EMULATION
@@ -293,11 +319,7 @@ bool wait_button_pressed() {
 
 int parse_token_info(const file_t *f, int mode) {
     (void)f;
-#ifdef __FOR_CI
-    char *label = "SmartCard-HSM";
-#else
-    char *label = "Pico-HSM";
-#endif
+    const char *label = get_card_label();
     char *manu = "Pol Henarejos";
     if (mode == 1) {
         uint8_t *p = res_APDU;
@@ -320,11 +342,7 @@ int parse_token_info(const file_t *f, int mode) {
 
 int parse_ef_dir(const file_t *f, int mode) {
     (void)f;
-#ifdef __FOR_CI
-    char *label = "SmartCard-HSM";
-#else
-    char *label = "Pico-HSM";
-#endif
+    const char *label = get_card_label();
     if (mode == 1) {
         uint8_t *p = res_APDU;
         *p++ = 0x61;


### PR DESCRIPTION
## Summary

- implement get_card_label function in sc_hsm.c
- update relevant callback functions _parse_token_info_ and _parse_ef_dir_

## Details / Impact
- initilization with sc-hsm-tool and label option worked:
`sc-hsm-tool --initialize --so-pin 3537363231383830 --pin 648219 --label "Test123ThisIsAVeryLongHSMLabel"`
- showing label details of the connected hsm with _pkcs15-tool -D_ worked
- ToDo: Check why callback to parse_token_info will cause a crash of the pico

## Testing
- tested on raspberry pi pico (RP2-B2)


## Licensing confirmation (required)

By checking the box below, you confirm ALL of the following:

- You are the author of this contribution, or you have the right to contribute it.
- You have read `CONTRIBUTING.md`.
- You agree that this contribution may be merged, used, modified, and redistributed:
  - under the AGPLv3 Community Edition, **and**
  - under any proprietary / commercial / Enterprise editions of this project,
    now or in the future.
- You understand that submitting this PR does not create any support obligation,
  SLA, or guarantee of merge.

**I confirm the above licensing terms:**

- [X] Yes, I agree


## Anything else?
I am not aware if removing of the parse_token_info callback for file 0x2f03 will have any cons for other functions.
