### PR TITLE
Harden UNWRAP KEY blob parser and related security-review findings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
 
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+        queries: security-extended,security-and-quality
 
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Python virtual environments
+.venv/
+venv/
+env/
+
+# Python bytecode / caches
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Build output
+build/
+build_*/
+*.uf2
+*.bin
+*.elf
+
+# Local emulator / test state
+tests/memory.flash
+.pico-hsm-emulation/
+
+# Editor / OS cruft
+.DS_Store
+Thumbs.db

--- a/src/hsm/cmd_pso.c
+++ b/src/hsm/cmd_pso.c
@@ -90,6 +90,10 @@ int cmd_pso(void) {
                     uint16_t plen = (uint16_t)mbedtls_mpi_size(&grp.P);
                     uint16_t t86_len = 0;
                     const uint8_t *t86 = cvc_get_field(puk, puk_len, &t86_len, 0x86);
+                    if (t86 == NULL) {
+                        mbedtls_ecp_group_free(&grp);
+                        return SW_WRONG_DATA();
+                    }
                     if (mbedtls_ecp_get_type(&grp) == MBEDTLS_ECP_TYPE_MONTGOMERY) {
                         if (plen != t86_len) {
                             mbedtls_ecp_group_free(&grp);
@@ -129,6 +133,9 @@ int cmd_pso(void) {
                     return SW_EXEC_ERROR();
                 }
                 uint8_t *buf = (uint8_t *) calloc(cd_len, sizeof(uint8_t));
+                if (buf == NULL) {
+                    return SW_MEMORY_FAILURE();
+                }
                 r = (int)asn1_build_cert_description(chr, chr_len, puk_bin, puk_bin_len, fid, buf, cd_len);
                 file_put_data(cd_ef, buf, cd_len);
                 free(buf);

--- a/src/hsm/kek.c
+++ b/src/hsm/kek.c
@@ -441,6 +441,12 @@ int mkek_load_key_file(file_t *file, uint8_t *data, uint16_t *len, uint16_t oper
         }
         return r;
     }
+    // Authorization asymmetry (by design): container / object-prefix keys are
+    // gated here by the fine-grained object policy (e.g. EXPORT requires the
+    // SO-PIN). Legacy KEY_PREFIX keys have no per-operation policy record and
+    // rely solely on the caller's isUserAuthenticated gate. The storage format
+    // is chosen by firmware (new keys prefer the container), not by the caller,
+    // so this cannot be used to downgrade a key's authorization at runtime.
     if ((file->fid >> 8) == HSM_OBJECT_PREFIX && !hsm_object_authorization_key_operation(operation, internal_firmware)) {
         return PICOKEYS_NO_LOGIN;
     }
@@ -640,7 +646,49 @@ int dkek_type_key(const uint8_t *in) {
     return 0x0;
 }
 
+/* Constant-time comparison of authentication tags/verifiers. Returns 0 on a
+ * full match, non-zero otherwise, without early-out timing leaks. */
+static int ct_memcmp(const void *a, const void *b, size_t len) {
+    const volatile uint8_t *pa = (const volatile uint8_t *) a;
+    const volatile uint8_t *pb = (const volatile uint8_t *) b;
+    uint8_t diff = 0;
+    for (size_t i = 0; i < len; i++) {
+        diff |= (uint8_t) (pa[i] ^ pb[i]);
+    }
+    return diff;
+}
+
+/* Reads a 16-bit length prefix at kb[*ofs], advancing *ofs past the length
+ * field, and validates that both the field and the value it introduces stay
+ * within `limit`. The decrypted key blob is attacker-authored even after the
+ * CMAC check succeeds, so every length must be bounds-checked before use. */
+static bool dkek_kb_read_len(const uint8_t *kb, uint16_t *ofs, uint16_t limit, uint16_t *out_len) {
+    if ((uint32_t) *ofs + 2u > limit) {
+        return false;
+    }
+    uint16_t l = get_uint16_be(kb + *ofs);
+    if ((uint32_t) *ofs + 2u + l > limit) {
+        return false;
+    }
+    *ofs += 2u;
+    *out_len = l;
+    return true;
+}
+
+/* Skips a length-prefixed field entirely, bounds-checked against `limit`. */
+static bool dkek_kb_skip(const uint8_t *kb, uint16_t *ofs, uint16_t limit) {
+    uint16_t l = 0;
+    if (!dkek_kb_read_len(kb, ofs, limit, &l)) {
+        return false;
+    }
+    *ofs += l;
+    return true;
+}
+
 int dkek_decode_key(uint8_t id, void *key_ctx, const uint8_t *in, uint16_t in_len, int *key_size_out, uint8_t **allowed, uint16_t *allowed_len) {
+    if (in == NULL || in_len < 9u + 12u + 16u) { // KCV + type + fixed algo OID + CMAC tag
+        return PICOKEYS_WRONG_DATA;
+    }
     uint8_t kcv[8];
     int r = 0;
     memset(kcv, 0, sizeof(kcv));
@@ -663,7 +711,7 @@ int dkek_decode_key(uint8_t id, void *key_ctx, const uint8_t *in, uint16_t in_le
         return r;
     }
 
-    if (memcmp(kcv, in, 8) != 0) {
+    if (ct_memcmp(kcv, in, 8) != 0) {
         return PICOKEYS_WRONG_DKEK;
     }
 
@@ -672,7 +720,7 @@ int dkek_decode_key(uint8_t id, void *key_ctx, const uint8_t *in, uint16_t in_le
     if (r != 0) {
         return PICOKEYS_WRONG_SIGNATURE;
     }
-    if (memcmp(signature, in + in_len - 16, 16) != 0) {
+    if (ct_memcmp(signature, in + in_len - 16, 16) != 0) {
         return PICOKEYS_WRONG_SIGNATURE;
     }
 
@@ -695,37 +743,44 @@ int dkek_decode_key(uint8_t id, void *key_ctx, const uint8_t *in, uint16_t in_le
         return PICOKEYS_WRONG_DATA;
     }
 
+    // The 4 length-prefixed header fields (OID, allowed algorithms, access
+    // conditions, key OID) plus the encrypted key body must all lie within the
+    // CMAC-authenticated region (in_len minus the 16-byte tag). These lengths
+    // are attacker-authored (the CMAC only proves a DKEK holder produced them),
+    // so validate every advance to avoid over-reads and offset wraparound.
+    uint16_t body = (uint16_t) (in_len - 16);
     uint16_t ofs = 9;
+    uint16_t len = 0, g_len = 0;
+    for (int field = 0; field < 4; field++) {
+        if ((uint32_t) ofs + 2u > body) {
+            return PICOKEYS_WRONG_DATA;
+        }
+        uint16_t flen = get_uint16_be(in + ofs);
+        if (field == 1) { // Allowed algorithms
+            *allowed = (uint8_t *) (in + ofs + 2);
+            *allowed_len = flen;
+        }
+        if ((uint32_t) ofs + 2u + flen > body) {
+            return PICOKEYS_WRONG_DATA;
+        }
+        ofs += (uint16_t) (2u + flen);
+    }
 
-    //OID
-    uint16_t len = get_uint16_be(in + ofs);
-    ofs += len + 2;
-
-    //Allowed algorithms
-    len = get_uint16_be(in + ofs);
-    *allowed = (uint8_t *) (in + ofs + 2);
-    *allowed_len = len;
-    ofs += len + 2;
-
-    //Access conditions
-    len = get_uint16_be(in + ofs);
-    ofs += len + 2;
-
-    //Key OID
-    len = get_uint16_be(in + ofs);
-    ofs += len + 2;
-
-    if ((in_len - 16 - ofs) % 16 != 0) {
+    uint16_t enc_len = (uint16_t) (body - ofs);
+    uint8_t kb[8 + 2 * 4 + 2 * 4096 / 8 + 3 + 13]; //worst case: RSA-4096  (plus, 13 bytes padding)
+    if (enc_len == 0 || enc_len % 16 != 0 || enc_len > sizeof(kb)) {
         return PICOKEYS_WRONG_PADDING;
     }
-    uint8_t kb[8 + 2 * 4 + 2 * 4096 / 8 + 3 + 13]; //worst case: RSA-4096  (plus, 13 bytes padding)
     memset(kb, 0, sizeof(kb));
-    memcpy(kb, in + ofs, in_len - 16 - ofs);
-    r = aes_decrypt(kenc, NULL, 256, PICOKEYS_AES_MODE_CBC, kb, in_len - 16 - ofs);
+    memcpy(kb, in + ofs, enc_len);
+    r = aes_decrypt(kenc, NULL, 256, PICOKEYS_AES_MODE_CBC, kb, enc_len);
     if (r != PICOKEYS_OK) {
         return r;
     }
 
+    if (enc_len < 10) { // key size lives at kb[8..9]
+        return PICOKEYS_WRONG_DATA;
+    }
     int key_size = get_uint16_be(kb + 8);
     if (key_size_out) {
         *key_size_out = key_size;
@@ -735,14 +790,20 @@ int dkek_decode_key(uint8_t id, void *key_ctx, const uint8_t *in, uint16_t in_le
         mbedtls_rsa_context *rsa = (mbedtls_rsa_context *) key_ctx;
         mbedtls_rsa_init(rsa);
         if (key_type == 5) {
-            len = get_uint16_be(kb + ofs); ofs += 2;
+            if (!dkek_kb_read_len(kb, &ofs, enc_len, &len)) {
+                mbedtls_rsa_free(rsa);
+                return PICOKEYS_WRONG_DATA;
+            }
             r = mbedtls_mpi_read_binary(&rsa->D, kb + ofs, len); ofs += len;
             if (r != 0) {
                 mbedtls_rsa_free(rsa);
                 return PICOKEYS_WRONG_DATA;
             }
 
-            len = get_uint16_be(kb + ofs); ofs += 2;
+            if (!dkek_kb_read_len(kb, &ofs, enc_len, &len)) {
+                mbedtls_rsa_free(rsa);
+                return PICOKEYS_WRONG_DATA;
+            }
             r = mbedtls_mpi_read_binary(&rsa->N, kb + ofs, len); ofs += len;
             if (r != 0) {
                 mbedtls_rsa_free(rsa);
@@ -751,12 +812,21 @@ int dkek_decode_key(uint8_t id, void *key_ctx, const uint8_t *in, uint16_t in_le
         }
         else if (key_type == 6) {
             //DP-1
-            len = get_uint16_be(kb + ofs); ofs += len + 2;
+            if (!dkek_kb_skip(kb, &ofs, enc_len)) {
+                mbedtls_rsa_free(rsa);
+                return PICOKEYS_WRONG_DATA;
+            }
 
             //DQ-1
-            len = get_uint16_be(kb + ofs); ofs += len + 2;
+            if (!dkek_kb_skip(kb, &ofs, enc_len)) {
+                mbedtls_rsa_free(rsa);
+                return PICOKEYS_WRONG_DATA;
+            }
 
-            len = get_uint16_be(kb + ofs); ofs += 2;
+            if (!dkek_kb_read_len(kb, &ofs, enc_len, &len)) {
+                mbedtls_rsa_free(rsa);
+                return PICOKEYS_WRONG_DATA;
+            }
             r = mbedtls_mpi_read_binary(&rsa->P, kb + ofs, len); ofs += len;
             if (r != 0) {
                 mbedtls_rsa_free(rsa);
@@ -764,19 +834,31 @@ int dkek_decode_key(uint8_t id, void *key_ctx, const uint8_t *in, uint16_t in_le
             }
 
             //PQ
-            len = get_uint16_be(kb + ofs); ofs += len + 2;
+            if (!dkek_kb_skip(kb, &ofs, enc_len)) {
+                mbedtls_rsa_free(rsa);
+                return PICOKEYS_WRONG_DATA;
+            }
 
-            len = get_uint16_be(kb + ofs); ofs += 2;
+            if (!dkek_kb_read_len(kb, &ofs, enc_len, &len)) {
+                mbedtls_rsa_free(rsa);
+                return PICOKEYS_WRONG_DATA;
+            }
             r = mbedtls_mpi_read_binary(&rsa->Q, kb + ofs, len); ofs += len;
             if (r != 0) {
                 mbedtls_rsa_free(rsa);
                 return PICOKEYS_WRONG_DATA;
             }
             //N
-            len = get_uint16_be(kb + ofs); ofs += len + 2;
+            if (!dkek_kb_skip(kb, &ofs, enc_len)) {
+                mbedtls_rsa_free(rsa);
+                return PICOKEYS_WRONG_DATA;
+            }
         }
 
-        len = get_uint16_be(kb + ofs); ofs += 2;
+        if (!dkek_kb_read_len(kb, &ofs, enc_len, &len)) {
+            mbedtls_rsa_free(rsa);
+            return PICOKEYS_WRONG_DATA;
+        }
         r = mbedtls_mpi_read_binary(&rsa->E, kb + ofs, len); ofs += len;
         if (r != 0) {
             mbedtls_rsa_free(rsa);
@@ -814,13 +896,22 @@ int dkek_decode_key(uint8_t id, void *key_ctx, const uint8_t *in, uint16_t in_le
         mbedtls_ecdsa_init(ecdsa);
 
         //A
-        len = get_uint16_be(kb + ofs); ofs += len + 2;
+        if (!dkek_kb_skip(kb, &ofs, enc_len)) {
+            mbedtls_ecdsa_free(ecdsa);
+            return PICOKEYS_WRONG_DATA;
+        }
 
         //B
-        len = get_uint16_be(kb + ofs); ofs += len + 2;
+        if (!dkek_kb_skip(kb, &ofs, enc_len)) {
+            mbedtls_ecdsa_free(ecdsa);
+            return PICOKEYS_WRONG_DATA;
+        }
 
         //P
-        len = get_uint16_be(kb + ofs); ofs += 2;
+        if (!dkek_kb_read_len(kb, &ofs, enc_len, &len)) {
+            mbedtls_ecdsa_free(ecdsa);
+            return PICOKEYS_WRONG_DATA;
+        }
         mbedtls_ecp_group_id ec_id = ec_get_curve_from_prime(kb + ofs, len);
         if (ec_id == MBEDTLS_ECP_DP_NONE) {
             mbedtls_ecdsa_free(ecdsa);
@@ -829,16 +920,26 @@ int dkek_decode_key(uint8_t id, void *key_ctx, const uint8_t *in, uint16_t in_le
         ofs += len;
 
         //N
-        len = get_uint16_be(kb + ofs); ofs += len + 2;
+        if (!dkek_kb_skip(kb, &ofs, enc_len)) {
+            mbedtls_ecdsa_free(ecdsa);
+            return PICOKEYS_WRONG_DATA;
+        }
 
         //G
-        uint16_t g_len = get_uint16_be(kb + ofs);
-        ofs += g_len + 2;
+        if (!dkek_kb_read_len(kb, &ofs, enc_len, &g_len)) {
+            mbedtls_ecdsa_free(ecdsa);
+            return PICOKEYS_WRONG_DATA;
+        }
+        const uint8_t *g = kb + ofs; // G value (bounds already validated)
+        (void) g;
+        ofs += g_len;
 
         //d
-        len = get_uint16_be(kb + ofs);
+        if (!dkek_kb_read_len(kb, &ofs, enc_len, &len)) {
+            mbedtls_ecdsa_free(ecdsa);
+            return PICOKEYS_WRONG_DATA;
+        }
 #ifdef MBEDTLS_EDDSA_C
-        const uint8_t *g = kb + ofs - g_len;
         if (ec_id == MBEDTLS_ECP_DP_CURVE25519 || ec_id == MBEDTLS_ECP_DP_ED25519) {
             ec_id = (g_len == 32 && g[0] == 0x09) ? MBEDTLS_ECP_DP_CURVE25519 : MBEDTLS_ECP_DP_ED25519;
         }
@@ -846,7 +947,6 @@ int dkek_decode_key(uint8_t id, void *key_ctx, const uint8_t *in, uint16_t in_le
             ec_id = (g_len == 56 && g[0] == 0x05 && len == 56) ? MBEDTLS_ECP_DP_CURVE448 : MBEDTLS_ECP_DP_ED448;
         }
 #endif
-        ofs += 2;
         r = mbedtls_ecp_read_key(ec_id, ecdsa, kb + ofs, len);
         if (r != 0) {
             mbedtls_ecdsa_free(ecdsa);
@@ -855,7 +955,10 @@ int dkek_decode_key(uint8_t id, void *key_ctx, const uint8_t *in, uint16_t in_le
         ofs += len;
 
         //Q
-        len = get_uint16_be(kb + ofs); ofs += 2;
+        if (!dkek_kb_read_len(kb, &ofs, enc_len, &len)) {
+            mbedtls_ecdsa_free(ecdsa);
+            return PICOKEYS_WRONG_DATA;
+        }
         r = mbedtls_ecp_point_read_binary(&ecdsa->grp, &ecdsa->Q, kb + ofs, len);
         if (r != 0) {
             r = mbedtls_ecp_keypair_calc_public(ecdsa, random_fill_iterator, NULL);
@@ -871,6 +974,11 @@ int dkek_decode_key(uint8_t id, void *key_ctx, const uint8_t *in, uint16_t in_le
         }
     }
     else if (key_type == 15) {
+        // key_ctx is a fixed 64-byte AES buffer in the caller; key_size and the
+        // offset are attacker-authored, so both must be bounded before copy.
+        if (key_size < 0 || key_size > 64 || (uint32_t) ofs + (uint32_t) key_size > enc_len) {
+            return PICOKEYS_WRONG_DATA;
+        }
         memcpy(key_ctx, kb + ofs, key_size);
     }
     return PICOKEYS_OK;

--- a/src/hsm/sc_hsm.c
+++ b/src/hsm/sc_hsm.c
@@ -174,6 +174,9 @@ int add_cert_puk_store(const uint8_t *data, uint16_t data_len, bool copy) {
     puk_store[puk_store_entries].copied = copy;
     if (copy == true) {
         uint8_t *tmp = (uint8_t *) calloc(data_len, sizeof(uint8_t));
+        if (tmp == NULL) {
+            return PICOKEYS_ERR_MEMORY_FATAL;
+        }
         memcpy(tmp, data, data_len);
         puk_store[puk_store_entries].cvcert = tmp;
     }
@@ -389,6 +392,18 @@ bool pka_enabled(void) {
     return file_has_data(ef_puk) && file_read_uint8(ef_puk) > 0;
 }
 
+/* Constant-time comparison, returns 0 on a full match. Used for PIN-verifier
+ * checks so the number of matching leading bytes is not exposed via timing. */
+static int ct_memcmp(const void *a, const void *b, size_t len) {
+    const volatile uint8_t *pa = (const volatile uint8_t *) a;
+    const volatile uint8_t *pb = (const volatile uint8_t *) b;
+    uint8_t diff = 0;
+    for (size_t i = 0; i < len; i++) {
+        diff |= (uint8_t) (pa[i] ^ pb[i]);
+    }
+    return diff;
+}
+
 uint16_t check_pin(const file_t *pin, const uint8_t *data, uint16_t len) {
     if (!file_has_data((file_t *) pin)) {
         return SW_REFERENCE_NOT_FOUND();
@@ -409,7 +424,7 @@ uint16_t check_pin(const file_t *pin, const uint8_t *data, uint16_t len) {
     else {
         return SW_WRONG_DATA();
     }
-    if (memcmp(file_get_data(pin) + off, dhash, sizeof(dhash)) != 0) {
+    if (ct_memcmp(file_get_data(pin) + off, dhash, sizeof(dhash)) != 0) {
         int retries;
         if ((retries = pin_wrong_retry(pin)) < PICOKEYS_OK) {
             return SW_PIN_BLOCKED();

--- a/tests/pico-hsm/test_014_key_unwrap_hardening.py
+++ b/tests/pico-hsm/test_014_key_unwrap_hardening.py
@@ -1,0 +1,147 @@
+"""
+/*
+ * This file is part of the Pico HSM distribution (https://github.com/polhenarejos/pico-hsm).
+ * Copyright (c) 2022 Pol Henarejos.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+Regression tests for the UNWRAP KEY (INS 0x74) blob parser hardening in
+kek.c:dkek_decode_key(). A wrapped-key blob carries a DKEK-keyed CMAC, so only
+a DKEK holder can produce one that authenticates -- but the length fields inside
+the blob are still attacker-authored. Historically the parser trusted those
+lengths: an oversized declared AES key size drove a memcpy() straight past the
+64-byte stack buffer in cmd_key_unwrap, an oversized header field ran the offset
+past the input, and a short blob underflowed the CMAC length. These tests forge
+blobs with a *valid* CMAC (the emulator's DKEK is all-zero after importing the
+[1]*32 share twice) and assert the firmware now rejects each with a clean status
+word and stays responsive, rather than crashing.
+"""
+
+import hashlib
+import os
+import struct
+
+import pytest
+
+from picokey import APDUResponse
+from picohsm.DO import DOPrefixes
+from picohsm.const import DEFAULT_PIN, DEFAULT_RETRIES, DEFAULT_DKEK_SHARES
+from const import DEFAULT_DKEK
+from cryptography.hazmat.primitives import cmac
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+# Effective device DKEK for key domain 0 after importing DEFAULT_DKEK ([1]*32)
+# twice: 0x01 XOR 0x01 == 0x00 for every byte.
+ZERO_DKEK = b"\x00" * 32
+AES_OID = b"\x00\x08\x60\x86\x48\x01\x65\x03\x04\x01"
+INS_UNWRAP = 0x74
+
+
+def _dkek_keys(dkek=ZERO_DKEK):
+    kcv = hashlib.sha256(dkek).digest()[:8]
+    kenc = hashlib.sha256(dkek + b"\x00\x00\x00\x01").digest()
+    kmac = hashlib.sha256(dkek + b"\x00\x00\x00\x02").digest()
+    return kcv, kenc, kmac
+
+
+def _seal(header, kb_plain, dkek=ZERO_DKEK):
+    """Encrypt the key body under KENC and append the DKEK CMAC, exactly as a
+    legitimate host wrapper would -- so the resulting blob authenticates and the
+    firmware reaches the field parser under test."""
+    assert len(kb_plain) % 16 == 0
+    _, kenc, kmac = _dkek_keys(dkek)
+    enc = Cipher(algorithms.AES(kenc), modes.CBC(b"\x00" * 16)).encryptor()
+    ct = enc.update(kb_plain) + enc.finalize()
+    blob = header + ct
+    c = cmac.CMAC(algorithms.AES(kmac))
+    c.update(blob)
+    return blob + c.finalize()
+
+
+def _aes_header(fields=b"\x00" * 6):
+    # kcv || type(0x0F=AES) || algo OID || {allowed, access, keyOID} length-TLVs
+    kcv, _, _ = _dkek_keys()
+    return kcv + b"\x0F" + AES_OID + fields
+
+
+def _aes_kb(declared_size, key_body):
+    # 8 random bytes || 2-byte declared key size || key || zero pad to a block.
+    kb = os.urandom(8) + struct.pack(">H", declared_size) + key_body
+    kb += b"\x00" * ((-len(kb)) % 16)
+    return kb
+
+
+def _prepare(device):
+    device.initialize(retries=DEFAULT_RETRIES, dkek_shares=DEFAULT_DKEK_SHARES)
+    device.login(DEFAULT_PIN)
+    device.import_dkek(DEFAULT_DKEK)
+    device.import_dkek(DEFAULT_DKEK)
+    # Sanity: the reconstructed DKEK matches ZERO_DKEK's check value.
+    assert hashlib.sha256(ZERO_DKEK).digest()[:8] == _dkek_keys()[0]
+
+
+def _raw_unwrap(device, blob):
+    # Low-level transport so an error SW surfaces as APDUResponse rather than the
+    # auto PIN-retry path in PicoHSM.send.
+    free = device.get_first_free_id()
+    return device._PicoHSM__card.send(
+        command=INS_UNWRAP, cla=0x80, p1=free, p2=0x93, data=list(blob), codes=[]
+    )
+
+
+def test_00_wellformed_manual_wrap_roundtrips(device):
+    # Anchor test: proves the hand-rolled sealer matches what the device expects,
+    # so the rejection tests below fail for the right reason (bad structure), not
+    # a MAC/KCV mismatch.
+    _prepare(device)
+    key = os.urandom(32)
+    blob = _seal(_aes_header(), _aes_kb(32, key))
+    free = device.get_first_free_id()
+    _, sw = device._PicoHSM__card.send(
+        command=INS_UNWRAP, cla=0x80, p1=free, p2=0x93, data=list(blob), codes=[]
+    )
+    assert sw == 0x9000
+    device.delete_file(DOPrefixes.KEY_PREFIX, free)
+
+
+def test_01_oversized_aes_key_size_rejected(device):
+    # Finding #1 (AES branch): declared key size 0x0400 with a 16-byte body would
+    # have memcpy'd 1024 bytes into the caller's aes_key[64] stack buffer.
+    _prepare(device)
+    blob = _seal(_aes_header(), _aes_kb(0x0400, os.urandom(16)))
+    with pytest.raises(APDUResponse):
+        _raw_unwrap(device, blob)
+    assert device.get_version() > 0
+
+
+def test_02_oversized_header_field_rejected(device):
+    # Finding #1 (header walk): an allowed-algorithms length of 0xFFFF with no
+    # value runs the offset past the input and makes (in_len - 16 - ofs) go
+    # negative.
+    _prepare(device)
+    header = _dkek_keys()[0] + b"\x0F" + AES_OID + struct.pack(">H", 0xFFFF)
+    blob = _seal(header, _aes_kb(32, os.urandom(32)))
+    with pytest.raises(APDUResponse):
+        _raw_unwrap(device, blob)
+    assert device.get_version() > 0
+
+
+def test_03_truncated_blob_rejected(device):
+    # Finding #1 (length guard): a blob shorter than the fixed header + CMAC tag
+    # would have driven the CMAC length (in_len - 16) below zero.
+    _prepare(device)
+    blob = _dkek_keys()[0] + b"\x0F" + b"\x00\x00\x00"  # 12 bytes total
+    with pytest.raises(APDUResponse):
+        _raw_unwrap(device, blob)
+    assert device.get_version() > 0

--- a/tests/start-up-and-test.sh
+++ b/tests/start-up-and-test.sh
@@ -2,4 +2,4 @@
 
 source ./tests/startup.sh
 
-# pytest tests -W ignore::DeprecationWarning
+pytest tests -W ignore::DeprecationWarning

--- a/tools/secure_key/macos.py
+++ b/tools/secure_key/macos.py
@@ -18,6 +18,13 @@ except:
     sys.exit(-1)
 
 
+# SECURITY NOTE: this backend currently stores the device-unlock private key as
+# an *extractable software key* in the login keychain, NOT hardware-bound in the
+# Secure Enclave. use_secure_enclave defaults to False because enabling it
+# segfaults the (non-code-signed) Python interpreter, and is_extractable=True is
+# required so get_secure_key() can return the raw scalar to pico-hsm-tool.
+# TODO: ship a code-signed interpreter and set use_secure_enclave=True /
+# is_extractable=False so the key becomes non-exportable and hardware-protected.
 def get_backend(use_secure_enclave=False):
     backend = OSXKeychainKeysBackend(
         key_type=OSXKeychainKeyType.EC, # Key type, e.g. RSA, RC, DSA, ...

--- a/tools/secure_key/windows.py
+++ b/tools/secure_key/windows.py
@@ -1,3 +1,19 @@
+"""Host-side storage for the P-256 device-unlock private key.
+
+SECURITY MODEL: the scalar stored here is the secret that unlocks the HSM's
+device authentication. It is persisted through the OS keyring (Windows
+Credential Manager / libsecret on Linux), which protects it at rest under the
+logged-in user account. It is, however, an *extractable software key*: the raw
+32-byte private scalar is returned to the caller in process memory (see get_d),
+and the PKCS8 blob handed to the keyring is serialized with NoEncryption()
+because the keyring, not this layer, provides encryption at rest.
+
+Defense-in-depth recommendations: run on a machine with full-disk encryption,
+keep the OS account locked, and treat a compromise of the user session as a
+compromise of the unlock key. Hardware binding (TPM-sealed keys) is not yet
+implemented on this backend.
+"""
+
 import sys
 import os
 import base64


### PR DESCRIPTION
This branch addresses findings from a security review of the SC-HSM object-container work, plus supporting test/CI wiring.

## Firmware

- **`kek.c` — DKEK-wrapped key parser hardening (memory safety).** Length fields inside a wrapped-key blob are attacker-authored even after the DKEK CMAC verifies, but were trusted. An oversized declared AES key size drove a `memcpy()` past the caller's 64-byte stack buffer; an oversized header field ran the parse offset past the input (with `uint16` wraparound); a short blob underflowed the CMAC length. Added an input-length guard, a bounds-checked header walk, an `enc_len` clamp to the key-block buffer, bounds-checked field readers (`dkek_kb_read_len`/`dkek_kb_skip`) for every RSA/EC field, and an AES `key_size` ceiling.
- **Constant-time comparisons** for the PIN verifier (`sc_hsm.c`) and the DKEK KCV + CMAC tag (`kek.c`).
- **NULL-deref / unchecked-alloc guards**: CVC `0x86` point field and cert-description `calloc` in `cmd_pso.c`; puk-store `calloc` in `sc_hsm.c`.
- **Doc**: comment clarifying the by-design authorization asymmetry between legacy and container key storage (`kek.c`).

## Tooling / CI / hygiene

- `tools/secure_key/*`: document that the host unlock key is an extractable software key; TODO to hardware-bind it.
- CodeQL: enable the `security-extended,security-and-quality` query packs.
- Add a root `.gitignore`.

## Tests

- `tests/pico-hsm/test_014_key_unwrap_hardening.py`: forges wrapped-key blobs carrying a valid DKEK CMAC (the emulator DKEK is all-zero after importing the `[1]*32` share twice) and asserts the firmware rejects the oversized-key, oversized-header, and truncated cases with a clean status word instead of crashing.
- `tests/start-up-and-test.sh`: the `pytest tests` invocation was commented out, so no Python integration test ran in CI. Re-enabled it.

## Verification

- Full emulation build (`ENABLE_EMULATION=1 __FOR_CI=1 ENABLE_EDDSA=1`) succeeds; `kek.c`, `sc_hsm.c`, `cmd_pso.c` compile with no warnings/errors.
- The verbatim patched parser logic was compiled with clang and run against the four test vectors (well-formed accepted; oversized-AES / header-overflow / truncated each rejected by the specific guard added).
- Runtime pytest was **not** run locally (the emulator fixture needs the `PICO_HSM_MEMORY_PASSPHRASE` CI secret) — it should run in CI now that the `pytest` line is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)