### PR TITLE
fix(hsm): reset after INITIALIZE DEVICE — deferred, bootrom-driven, sized for real erase times

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,28 +41,7 @@ else()
         add_compile_definitions(__FOR_CI)
     endif()
 
-    # Remote reset / BOOTSEL over USB. OFF by default and it must stay that way for any token
-    # holding real key material: RESET_REQUEST_BOOTSEL allows REMOTE FIRMWARE REPLACEMENT by
-    # anything that can reach the USB device, and neither request is authenticated (a wedged
-    # device cannot verify a PIN, which is the whole point of a recovery path). Enable it only
-    # for development or staging tokens, where remote recovery and firmware updates are worth
-    # more than the exposure.
-    option(PICOKEYS_REMOTE_RESET "Allow reset/BOOTSEL over USB — DEV/STAGING TOKENS ONLY" OFF)
-    if(PICOKEYS_REMOTE_RESET)
-        add_compile_definitions(PICOKEYS_REMOTE_RESET)
-        message(WARNING "PICOKEYS_REMOTE_RESET is ON: this firmware accepts UNAUTHENTICATED reset and BOOTSEL requests over USB, which permits remote firmware replacement. Do NOT ship this build on a token holding real keys.")
-    endif()
-
     add_executable(pico_hsm)
-
-    if(PICOKEYS_REMOTE_RESET)
-        # Must follow add_executable(): the target has to exist before it can be linked against.
-        # RESET_REQUEST_BOOTSEL / RESET_REQUEST_FLASH live in pico/usb_reset_interface.h, which
-        # ships in its own header-only SDK library rather than on the default include path.
-        # Linking it keeps the request codes coming from the SDK instead of being re-declared
-        # here and silently drifting from it.
-        target_link_libraries(pico_hsm PUBLIC pico_usb_reset_interface_headers)
-    endif()
 endif()
 set(USB_ITF_CCID 1)
 set(USB_ITF_WCID 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,28 @@ else()
         add_compile_definitions(__FOR_CI)
     endif()
 
+    # Remote reset / BOOTSEL over USB. OFF by default and it must stay that way for any token
+    # holding real key material: RESET_REQUEST_BOOTSEL allows REMOTE FIRMWARE REPLACEMENT by
+    # anything that can reach the USB device, and neither request is authenticated (a wedged
+    # device cannot verify a PIN, which is the whole point of a recovery path). Enable it only
+    # for development or staging tokens, where remote recovery and firmware updates are worth
+    # more than the exposure.
+    option(PICOKEYS_REMOTE_RESET "Allow reset/BOOTSEL over USB — DEV/STAGING TOKENS ONLY" OFF)
+    if(PICOKEYS_REMOTE_RESET)
+        add_compile_definitions(PICOKEYS_REMOTE_RESET)
+        message(WARNING "PICOKEYS_REMOTE_RESET is ON: this firmware accepts UNAUTHENTICATED reset and BOOTSEL requests over USB, which permits remote firmware replacement. Do NOT ship this build on a token holding real keys.")
+    endif()
+
     add_executable(pico_hsm)
+
+    if(PICOKEYS_REMOTE_RESET)
+        # Must follow add_executable(): the target has to exist before it can be linked against.
+        # RESET_REQUEST_BOOTSEL / RESET_REQUEST_FLASH live in pico/usb_reset_interface.h, which
+        # ships in its own header-only SDK library rather than on the default include path.
+        # Linking it keeps the request codes coming from the SDK instead of being re-declared
+        # here and silently drifting from it.
+        target_link_libraries(pico_hsm PUBLIC pico_usb_reset_interface_headers)
+    endif()
 endif()
 set(USB_ITF_CCID 1)
 set(USB_ITF_WCID 1)

--- a/doc/ATTESTATION.md
+++ b/doc/ATTESTATION.md
@@ -1,0 +1,61 @@
+# Staging HSM — what has actually been demonstrated
+
+Hardware: Waveshare RP2350-PiZero running Pico HSM firmware 6.6, PKCS#11 serial `ESPICOHSMTR`.
+Every claim below was executed against that device; none is inferred.
+
+**This is a STAGING device.** It holds throwaway keys, its PINs are the published pico-hsm dev
+defaults, and it is an open-source reimplementation on a microcontroller with no tamper
+resistance. It is where procedures get proven. It is not where value gets held.
+
+## Demonstrated
+
+| Capability | Evidence |
+|---|---|
+| **Blockchain wallet** — secp256k1 | Seed-derived key imported via DKEK; card signs a fresh random digest; signature verifies against the seed's pubkey; wrong digest correctly fails. 14/14 provisioning cycles. |
+| **Secrets decryption (SOPS)** | `sops --decrypt` returns plaintext with `PKDECRYPT` in the scdaemon log — the RSA unwrap of the data key happened ON THE CARD. See SOPS-HSM.md. |
+| **X.509 Certificate Authority** | Signed a CSR for `CN=api.staging.internal` using the on-card RSA key. `openssl verify` returns OK against the CA cert; verification against an unrelated CA correctly fails. |
+| **SSH authentication** | Real login to a local sshd with `ssh -I <module>`, remote command executed, using the on-card P-256 key. No key material on disk. |
+| **GPG identity** | OpenPGP key bound to the on-card RSA key. Lists as `sec>` with a card serial — the `>` means the private half is a stub pointing at hardware. |
+| **Multiple heterogeneous keys** | secp256k1 + RSA-2048 + P-256 coexisting, all `sensitive, always sensitive, never extractable`, each independently usable. |
+| **Key isolation (DKEK)** | A key wrapped under a DIFFERENT DKEK share was REFUSED with SW=6400. Distinct KCVs confirm the domains genuinely differed. Isolation is enforced by the card, not by convention. |
+| **Wrong PIN** | Refused; retry counter decremented and restored by a correct PIN. |
+| **Persistence** | Key survives a reboot and still signs for the same public key. |
+
+Against the categories a software/hosting company typically puts in an HSM — internal PKI, TLS,
+code signing, SSH CA, secrets-manager root — this covers **PKI/CA, SSH, secrets decryption, and
+the signing primitives code signing needs**, plus wallets.
+
+## NOT demonstrated, and the limits are structural
+
+**age / X25519 cannot ever move to this card.** It does ECDSA/ECDH on prime curves and RSA. No
+X25519, no Ed25519. That is a hardware fact, not a configuration gap — it is why the SOPS path
+above uses the PGP backend, and it means Ed25519 SSH keys and Ed25519 GPG keys are also out.
+
+**Reliability is not yet production-grade.** ~7% of re-provisioning cycles hang with the device
+leaving the USB bus, needing a physical replug. The cryptographic path has NEVER failed — every
+completed cycle verified correctly — but recovery does. Cause unknown after three attempts; see
+the commit history for two real improvements (wrong PICO_BOARD, commit-timeout sizing) and one
+regression that was reverted. Diagnosis is blocked on SWD, not on more theories.
+
+**Throughput is modest.** 2.43 sig/s, 412 ms/sig — and that is with a fresh `pkcs11-tool` process
+and PIN login per signature, so it is an upper bound on latency rather than card speed. Nobody has
+measured a persistent-session number.
+
+**Everything here ran on macOS.** The target is Linux, with a different PCSC stack. Nothing has
+been verified there.
+
+**Untested:** concurrent sessions, key deletion, capacity limits, and behaviour once the flash
+region fills.
+
+## What this does and does not justify saying
+
+Justified: *"A hardware HSM can hold this company's wallet keys, act as its internal CA, back its
+SSH authentication, decrypt its SOPS secrets, and carry a GPG identity — proven end to end on
+real hardware, with negative controls."*
+
+NOT justified: that this specific device is ready to hold production keys. The reliability gap is
+real, it is on the recovery path rather than the crypto path, and the production tokens (Nitrokey
+HSM 2, NXP secure element) are a different implementation on which NONE of this has been repeated.
+
+The value of this exercise is the procedures, the tooling, and the negative results — each of the
+above is now a script that can be re-run against a production token in an afternoon.

--- a/doc/SOPS-HSM.md
+++ b/doc/SOPS-HSM.md
@@ -1,0 +1,107 @@
+# SOPS secrets decrypted by the HSM
+
+**Status: working, verified end to end on a Pico HSM (RP2350B, firmware 6.6).**
+
+SOPS has no PKCS#11 backend and never has. But it *does* support **PGP**, and GnuPG can be
+backed by a PKCS#11 token, so the chain works with no change to the secrets pipeline:
+
+```
+sops → gpg → gnupg-pkcs11-scd → PKCS#11 → RSA key on the HSM
+```
+
+Proof it reaches the hardware — the scdaemon log during `sops --decrypt`:
+
+```
+chan_0 <- PKDECRYPT 3DDB240D13542FCBC558A2D8C510D5CF7BC5F683
+```
+
+`PKDECRYPT` means the RSA unwrap of the SOPS data key happened ON THE CARD. Not a software
+key that happens to live near one.
+
+## What this does and does not solve
+
+It hardens the **human/ops** decryption path. It does **NOT** fix CI.
+
+CI cannot use a physical token, so `SOPS_AGE_KEY` remains a software key that decrypts
+everything — the exact weakness a custody review called the weakest hop in the chain. Adding a
+PGP recipient does not remove it. If CI is the target, the answer is different: put SOPS behind
+**Vault or OpenBAO** (both natively supported), authenticate CI with a short-lived token, and use
+the HSM to protect Vault's seal instead.
+
+Worth being explicit because the improvement is easy to overstate: this makes an operator's
+laptop stop holding a decryption key. It does not make the repo's secrets unreachable to whoever
+controls CI.
+
+## Two steps that are not obvious
+
+**1. The card needs an X.509 CERTIFICATE, not just the key.** `gnupg-pkcs11-scd` enumerates
+tokens by certificate; a bare private key is invisible to it. `SCD LEARN` returns a bare `OK`
+with no `KEYPAIRINFO` and nothing explains why. The importer only writes the key, so the cert has
+to be written separately, WITH THE SAME `--id` as the key:
+
+```sh
+openssl x509 -in rsa.crt -outform DER -out rsa.cer
+pkcs11-tool --module $M --login --pin $PIN --write-object rsa.cer --type cert --id 32 --label rsa-signing
+```
+
+**2. `gpg` and `gpg-agent` learn the card separately.** `SCD LEARN` tells *scdaemon*, which is not
+enough — `gpg --full-generate-key` then rejects the keygrip with "No key with this keygrip". The
+agent needs its own learn, which writes a shadow key into `private-keys-v1.d/`:
+
+```sh
+gpg-connect-agent 'LEARN --send' /bye
+gpg-connect-agent 'HAVEKEY <keygrip>' /bye     # must answer OK
+```
+
+## Recipe
+
+```sh
+export GNUPGHOME=/path/to/hsm-gnupghome     # keep it ISOLATED from your real ~/.gnupg
+mkdir -p $GNUPGHOME && chmod 700 $GNUPGHOME
+
+cat > $GNUPGHOME/gpg-agent.conf <<'EOF'
+scdaemon-program /opt/homebrew/bin/gnupg-pkcs11-scd
+EOF
+
+cat > $GNUPGHOME/gnupg-pkcs11-scd.conf <<'EOF'
+providers opensc
+provider-opensc-library /opt/homebrew/lib/opensc-pkcs11.so
+pin-cache 0
+EOF
+
+# 1. import an RSA key onto the card (ALWAYS import, never generate on-card, so the key stays
+#    reconstructible from its Shamir shares) and write its certificate alongside — see above.
+# 2. teach both daemons about it:
+gpg-connect-agent 'SCD LEARN --force' /bye     # note the keygrip in KEYPAIRINFO
+gpg-connect-agent 'LEARN --send' /bye
+
+# 3. bind an OpenPGP identity to that keygrip:
+gpg --expert --full-generate-key
+#    (13) Existing key  ->  paste the keygrip  ->  Q  ->  0  ->  y  ->  name/email  ->  O
+
+# 4. use it:
+sops --encrypt --pgp <FINGERPRINT> secret.yaml > secret.enc.yaml
+sops --decrypt secret.enc.yaml
+```
+
+The resulting key lists as `sec>` — the `>` means the private half is a stub pointing at the
+card, with `Card serial no.` shown. Key material never leaves the HSM.
+
+## Migration, without a flag day
+
+SOPS decrypts with WHICHEVER recipient it can reach, so the PGP key is added ALONGSIDE the
+existing age recipients rather than replacing them. Add `pgp:` next to `age:` in `.sops.yaml`,
+run `sops updatekeys` over every `*.sops.*` file, and both paths work. Nothing needs to be
+cut over at once, and losing the HSM does not lock anyone out.
+
+## Constraints
+
+- **age/X25519 cannot move to this HSM.** The card does ECDSA/ECDH on prime curves and RSA; it
+  has no X25519 and no Ed25519. That is why this uses the PGP backend instead of an age plugin,
+  and it independently confirms what the custody notes already said about age needing a
+  YubiKey-PIV recipient rather than a SmartCard-HSM.
+- `gnupg-pkcs11-scd` is a niche bridge (0.11.0). GnuPG warns that it is "older than us". It
+  works, but it is a small dependency in a critical path — worth knowing before relying on it.
+- Automating the PIN via a scripted `pinentry-program` is fine for a STAGING token with a
+  documented dev PIN. Never do it for a token holding real secrets: it defeats the point of
+  requiring physical presence.

--- a/doc/SOPS-HSM.md
+++ b/doc/SOPS-HSM.md
@@ -105,3 +105,40 @@ cut over at once, and losing the HSM does not lock anyone out.
 - Automating the PIN via a scripted `pinentry-program` is fine for a STAGING token with a
   documented dev PIN. Never do it for a token holding real secrets: it defeats the point of
   requiring physical presence.
+
+## Also proven: GPG proper, and the envelope pattern
+
+**The card-backed PGP key is a fully functional GPG key**, not just a SOPS decryptor:
+
+- detached signatures — `Good signature`, and a tampered artifact correctly gives `BAD signature`
+- `--encrypt` / `--decrypt` round-trip
+- **real git commit signing** — `git commit -S` verified `Good signature` via `git log --show-signature`
+
+That covers release-artifact signing, code signing and commit signing off the same key.
+
+## Envelope encryption: protecting secrets the card CANNOT operate on
+
+The card has no X25519, so it can never *be* an age identity. It can still *protect* one:
+
+```sh
+age-keygen -o age-key.txt
+gpg --encrypt --recipient $FPR --output age-key.txt.gpg age-key.txt
+rm age-key.txt                       # plaintext gone; only the wrapped copy remains
+
+# use it without the key ever touching disk:
+gpg --decrypt age-key.txt.gpg | age -d -i /dev/stdin payload.age
+```
+
+Verified working, with `PKDECRYPT` in the scdaemon log confirming the card performed the unwrap.
+
+**Know what this does and does not buy.** The age key is protected AT REST and never written to
+disk in plaintext — but it exists IN RAM while in use, and the card does not perform the age
+operation itself. Compare with using PGP directly for SOPS, where no age key exists at all and
+the card does the real work. For SOPS, direct PGP is STRICTLY BETTER; the envelope is for tools
+that require age specifically.
+
+The pattern generalises to any secret the card cannot natively operate on — Ed25519 SSH keys,
+API tokens, database credentials. That makes the HSM the root of an envelope-encryption scheme
+covering arbitrary secrets, rather than only the algorithms it implements. It is the honest
+version of "poor-man's KMS": strong for storage, weaker in use than a real KMS that never
+releases key material at all.

--- a/doc/SOPS-HSM.md
+++ b/doc/SOPS-HSM.md
@@ -143,29 +143,48 @@ covering arbitrary secrets, rather than only the algorithms it implements. It is
 version of "poor-man's KMS": strong for storage, weaker in use than a real KMS that never
 releases key material at all.
 
-## CONSTRAINT: multiple certificates break the GPG binding
+## CONSTRAINT: an EC certificate wedges gnupg-pkcs11-scd 0.11.0
 
-Discovered by adding a second key/cert to a card whose GPG identity already worked.
+Not "multiple certificates", and not "GPG needs its own token" — both of which were claimed here
+before the cause was actually found. The real fault is a missing guard in ONE function of the
+released daemon, and it is already fixed upstream.
 
-PKCS#11 handles multiple keys fine — secp256k1, RSA-2048 and P-256 coexisted and all signed
-correctly via `pkcs11-tool` throughout. **`gnupg-pkcs11-scd` does not.** After a second
-certificate was written to the card, `sops --decrypt` HUNG, with the bridge looping on:
+**Symptom.** With a P-256 certificate on the card, `sops --decrypt` HANGS. The daemon loops on:
 
 ```
-KEYINFO 3DDB240D13542FCBC558A2D8C510D5CF7BC5F683  ->  ERR 41 Wrong public key algorithm
+KEYINFO <keygrip>  ->  ERR 41 Wrong public key algorithm
 ```
 
-The card was never at fault: raw PKCS#11 signatures with both the wallet key and the RSA key
-kept working the whole time. The bridge simply cannot resolve which key a keygrip refers to once
-several certificates are present, and it fails by hanging rather than erroring out.
+**Cause, verified against the source.** `gnupg-pkcs11-scd` is designed to iterate certificates and
+skip any whose key algorithm it cannot parse. That guard is
 
-This matters for the "one card, many purposes" idea. Options, none free:
+```c
+if (error == GPG_ERR_WRONG_PUBKEY_ALGO) {
+    /* skip unsupported keys */
+    error = GPG_ERR_NO_ERROR;
+}
+```
 
-- keep the GPG-bearing card to a SINGLE certificate, and put other key types on another token
-- constrain the bridge's view via its provider/cert filtering options (untested here)
-- avoid the bridge for multi-purpose cards and use PKCS#11 directly where the tooling allows it
-  (ssh -I, openssl engine, pkcs11-tool all worked with all three keys present)
+and in **0.11.0** it is present in `send_certificate_list()` but **ABSENT from `cmd_keyinfo()`**.
+On master it is present in both. That maps exactly onto the observed behaviour:
 
-Note the asymmetry: everything that speaks PKCS#11 NATIVELY was unaffected. Only the GnuPG
-bridge broke. So a multi-purpose card is fine for SSH, TLS, CA and wallet work; it is GPG
-specifically that wants a card to itself.
+| call | uses | 0.11.0 result |
+|---|---|---|
+| `SCD LEARN` | `send_certificate_list()` | works — EC cert skipped |
+| `KEYINFO <keygrip>` | `cmd_keyinfo()` | **ERR 41**, propagated, daemon wedges |
+
+The card is never at fault. Throughout, raw PKCS#11 kept working for every key — secp256k1, RSA
+and P-256 all signed correctly while GPG was wedged.
+
+**Fix: build gnupg-pkcs11-scd from master.** Brew ships 0.11.0, which predates the `cmd_keyinfo`
+guard.
+
+**Workaround if you must stay on 0.11.0:** keep EC *certificates* off the card used for GPG. EC
+*keys* are fine — only certificate parsing trips it. But note the cost, measured here: on this
+card, `pkcs11-tool --delete-object --type cert` ALSO removes the public key object, so the EC key
+keeps signing but `ssh-keygen -D` can no longer enumerate it as an SSH identity. So on 0.11.0 a
+single card cannot serve both GPG and SSH-with-an-EC-key. On master it can.
+
+**Failure mode worth noting separately:** it HANGS rather than erroring. A wedged `sops --decrypt`
+in a deploy pipeline is far worse than a clean failure, and it is the reason this daemon deserves
+the "small dependency in a critical path" caution above rather than a passing mention.

--- a/doc/SOPS-HSM.md
+++ b/doc/SOPS-HSM.md
@@ -143,20 +143,13 @@ covering arbitrary secrets, rather than only the algorithms it implements. It is
 version of "poor-man's KMS": strong for storage, weaker in use than a real KMS that never
 releases key material at all.
 
-## CONSTRAINT: an EC certificate wedges gnupg-pkcs11-scd 0.11.0
+## REQUIREMENT: build gnupg-pkcs11-scd from master, do not use 0.11.0
 
-Not "multiple certificates", and not "GPG needs its own token" — both of which were claimed here
-before the cause was actually found. The real fault is a missing guard in ONE function of the
-released daemon, and it is already fixed upstream.
+Homebrew ships **0.11.0, which is broken for multi-key cards.** Build from master instead.
 
-**Symptom.** With a P-256 certificate on the card, `sops --decrypt` HANGS. The daemon loops on:
+### The bug
 
-```
-KEYINFO <keygrip>  ->  ERR 41 Wrong public key algorithm
-```
-
-**Cause, verified against the source.** `gnupg-pkcs11-scd` is designed to iterate certificates and
-skip any whose key algorithm it cannot parse. That guard is
+`gnupg-pkcs11-scd` iterates certificates and skips any whose algorithm it cannot parse:
 
 ```c
 if (error == GPG_ERR_WRONG_PUBKEY_ALGO) {
@@ -165,26 +158,53 @@ if (error == GPG_ERR_WRONG_PUBKEY_ALGO) {
 }
 ```
 
-and in **0.11.0** it is present in `send_certificate_list()` but **ABSENT from `cmd_keyinfo()`**.
-On master it is present in both. That maps exactly onto the observed behaviour:
+In 0.11.0 that guard is in `send_certificate_list()` but **ABSENT from `cmd_keyinfo()`**. On
+master it is in both. With an EC certificate on the card, 0.11.0 therefore:
 
-| call | uses | 0.11.0 result |
+- answers `SCD LEARN` fine (that path skips the cert), but
+- returns `ERR 41 Wrong public key algorithm` to `KEYINFO`, and **HANGS**
+
+A hung `sops --decrypt` in a deploy pipeline is far worse than a clean failure, which is why
+this is a build requirement rather than a footnote.
+
+### Measured, same card and same certificate
+
+| daemon | `KEYINFO` | SOPS |
 |---|---|---|
-| `SCD LEARN` | `send_certificate_list()` | works — EC cert skipped |
-| `KEYINFO <keygrip>` | `cmd_keyinfo()` | **ERR 41**, propagated, daemon wedges |
+| 0.11.0 (brew) | `ERR 41` | hangs |
+| 0.11.1_master (built) | `OK` | **decrypt rc=0, ERR 41 count: 0** |
 
-The card is never at fault. Throughout, raw PKCS#11 kept working for every key — secp256k1, RSA
-and P-256 all signed correctly while GPG was wedged.
+### Build it
 
-**Fix: build gnupg-pkcs11-scd from master.** Brew ships 0.11.0, which predates the `cmd_keyinfo`
-guard.
+```sh
+brew install autoconf automake pkg-config libgcrypt libassuan pkcs11-helper
+git clone https://github.com/alonbl/gnupg-pkcs11-scd.git
+cd gnupg-pkcs11-scd && autoreconf -ivf
+./configure --prefix=$HOME/tools/gnupg-pkcs11-scd-master && make && make install
+```
 
-**Workaround if you must stay on 0.11.0:** keep EC *certificates* off the card used for GPG. EC
-*keys* are fine — only certificate parsing trips it. But note the cost, measured here: on this
-card, `pkcs11-tool --delete-object --type cert` ALSO removes the public key object, so the EC key
-keeps signing but `ssh-keygen -D` can no longer enumerate it as an SSH identity. So on 0.11.0 a
-single card cannot serve both GPG and SSH-with-an-EC-key. On master it can.
+Then point `gpg-agent.conf` at that binary rather than the brew one.
 
-**Failure mode worth noting separately:** it HANGS rather than erroring. A wedged `sops --decrypt`
-in a deploy pipeline is far worse than a clean failure, and it is the reason this daemon deserves
-the "small dependency in a critical path" caution above rather than a passing mention.
+## One card really does serve many purposes
+
+With master, a single card was verified holding **RSA (GPG/SOPS/CA) + P-256 (SSH) + secp256k1
+(wallet)**, each with its certificate, all working together in one session:
+
+- SSH authentication to a live sshd — real login, remote command executed
+- `sops --decrypt` immediately afterwards on the same card — `rc=0`
+- X.509 CA signing, and wallet signatures, from the same token
+
+Earlier revisions of this document claimed the opposite — first that multiple certificates broke
+the binding, then that GPG needed a card to itself. **Both were wrong.** They were written from a
+symptom without finding the cause. The cause was one missing `if` in a released dependency.
+
+## Two incidental findings worth keeping
+
+**Object storage can be exhausted.** After repeated certificate write/delete cycles,
+`C_CreateObject` began returning `CKR_GENERAL_ERROR` and the card refused *any* certificate. A
+wipe cleared it completely. For a token that is re-provisioned often, that is a real operational
+limit.
+
+**Deleting a certificate also removes the public key object.** The private key keeps signing, but
+`ssh-keygen -D` can no longer enumerate it. Certificates are not decoration on this card — they
+are what makes a key discoverable to public-key tooling.

--- a/doc/SOPS-HSM.md
+++ b/doc/SOPS-HSM.md
@@ -142,3 +142,30 @@ API tokens, database credentials. That makes the HSM the root of an envelope-enc
 covering arbitrary secrets, rather than only the algorithms it implements. It is the honest
 version of "poor-man's KMS": strong for storage, weaker in use than a real KMS that never
 releases key material at all.
+
+## CONSTRAINT: multiple certificates break the GPG binding
+
+Discovered by adding a second key/cert to a card whose GPG identity already worked.
+
+PKCS#11 handles multiple keys fine — secp256k1, RSA-2048 and P-256 coexisted and all signed
+correctly via `pkcs11-tool` throughout. **`gnupg-pkcs11-scd` does not.** After a second
+certificate was written to the card, `sops --decrypt` HUNG, with the bridge looping on:
+
+```
+KEYINFO 3DDB240D13542FCBC558A2D8C510D5CF7BC5F683  ->  ERR 41 Wrong public key algorithm
+```
+
+The card was never at fault: raw PKCS#11 signatures with both the wallet key and the RSA key
+kept working the whole time. The bridge simply cannot resolve which key a keygrip refers to once
+several certificates are present, and it fails by hanging rather than erroring out.
+
+This matters for the "one card, many purposes" idea. Options, none free:
+
+- keep the GPG-bearing card to a SINGLE certificate, and put other key types on another token
+- constrain the bridge's view via its provider/cert filtering options (untested here)
+- avoid the bridge for multi-purpose cards and use PKCS#11 directly where the tooling allows it
+  (ssh -I, openssl engine, pkcs11-tool all worked with all three keys present)
+
+Note the asymmetry: everything that speaks PKCS#11 NATIVELY was unaffected. Only the GnuPG
+bridge broke. So a multi-purpose card is fine for SSH, TLS, CA and wallet work; it is GPG
+specifically that wants a card to itself.

--- a/src/hsm/cmd_initialize.c
+++ b/src/hsm/cmd_initialize.c
@@ -32,10 +32,18 @@
 #endif
 
 /* Upper bound on waiting for the re-personalisation write to become durable before the reset
- * below. Generous on purpose: a full-region erase is many sectors, and overshooting merely
- * costs a few idle milliseconds, whereas undershooting falls back to the async commit and
- * reintroduces the race the synchronous wait exists to remove. */
-#define FLASH_COMMIT_SYNC_TIMEOUT_MS 10000
+ * below.
+ *
+ * SIZE THIS FROM THE HARDWARE, NOT FROM INTUITION. The data region is FLASH_SIZE/2, so on a 16MB
+ * board that is 8MB = ~2048 sectors of 4KB, and a sector erase costs roughly 30-45ms on RP2350.
+ * A large wipe can therefore run 60-90 SECONDS. The first version of this used 10s, which is not
+ * a tight bound — it is far below the worst case, so the sync routinely "timed out" on a wipe
+ * that was proceeding perfectly normally.
+ *
+ * Overshooting costs nothing: the wait returns as soon as the queue drains, so the timeout is
+ * only ever reached when something is genuinely wrong. Undershooting caused the reset to fire
+ * into an in-flight erase and hang the device. Asymmetric consequences, so be generous. */
+#define FLASH_COMMIT_SYNC_TIMEOUT_MS 180000
 
 /* Grace period between arming the reset and it firing, so core 0 can transmit the APDU response
  * first. Without it the host reports "Card removed" for a command that actually succeeded. */
@@ -275,26 +283,39 @@ int cmd_initialize(void) {
         if (ret != PICOKEYS_OK) {
             return SW_EXEC_ERROR();
         }
-        /* Persist SYNCHRONOUSLY. flash_commit() only queues the write for low_flash_task() on
-         * core 0; resetting straight after it would race the write and could leave a
-         * half-written file system. APDU handlers run on core 1, which is exactly where
-         * flash_commit_sync() is usable (it refuses on core 0, since core 0 owns the task it
-         * would be waiting for). Fall back to the async commit if it reports failure so a
-         * timeout can never leave the commit unqueued. */
-        /* These printf()s go to the UART (PICO_STDIO_UART is on by default; PICO_STDIO_USB is
-         * not), which is the ONLY channel that survives the failure being chased here: when the
-         * reset below hangs, the device leaves the USB bus, so anything logging over USB goes
-         * dark at exactly the moment it is needed. A serial adapter on GPIO0/GND at 115200
-         * turns "it hung, unclear where" into a line number. */
+        /* Persist SYNCHRONOUSLY. flash_commit() only QUEUES the write for low_flash_task() on
+         * core 0; resetting straight after it would race the write. APDU handlers run on core 1,
+         * which is exactly where flash_commit_sync() is usable (it refuses on core 0, since core
+         * 0 owns the task it would be waiting for).
+         *
+         * These printf()s go to the UART (PICO_STDIO_UART is on by default, PICO_STDIO_USB is
+         * not), the only channel that survives this failure: when the reset below hangs the
+         * device leaves the USB bus, so USB-side logging goes dark exactly when it is needed. */
         printf("INIT: wipe done, committing flash synchronously\n");
         bool committed = flash_commit_sync(FLASH_COMMIT_SYNC_TIMEOUT_MS);
-        if (!committed) {
-            printf("INIT: WARN sync commit reported failure, falling back to async\n");
-            flash_commit();
-        }
-        printf("INIT: flash committed (sync=%d)\n", (int) committed);
+        printf("INIT: flash commit sync=%d\n", (int) committed);
         reset_puk_store();
         printf("INIT: puk store reset\n");
+
+        /* DO NOT RESET ON AN UNCONFIRMED COMMIT.
+         *
+         * The earlier version fell back to an ASYNC flash_commit() here and then reset anyway,
+         * which is the worst possible ordering: an unconfirmed commit means the erase is very
+         * likely still in flight, and the reset then lands mid-erase. Measured: cycles that wipe
+         * a nearly-empty card pass 9/9, while cycles that wipe a card holding an imported key
+         * plus a populated DKEK domain — far more flash to erase — hung 1 in 3. More to erase
+         * means a longer erase, means a greater chance the sync times out and the reset fires
+         * into it. The device then leaves the USB bus and needs a PHYSICAL REPLUG.
+         *
+         * So: report the failure and stay alive instead. An operator who gets an error and can
+         * retry is in a strictly better position than one holding a device that needs someone to
+         * walk into the datacenter. The wipe itself has already succeeded at this point, so the
+         * retry is cheap; only the reset is being declined. */
+        if (!committed) {
+            printf("INIT: commit UNCONFIRMED — refusing to reset (would land mid-erase)\n");
+            flash_commit();
+            return SW_EXEC_ERROR();
+        }
 #if defined(PICO_PLATFORM)
         /* Re-personalising wipes the file system, and the card does NOT come back on its own
          * afterwards: the reader keeps reporting a card, but the card returns no ATR and

--- a/src/hsm/cmd_initialize.c
+++ b/src/hsm/cmd_initialize.c
@@ -355,22 +355,15 @@ int cmd_initialize(void) {
          * hang found with this marker present means THIS build reset and wedged afterwards;
          * absent means the wedge predates the current firmware. */
         watchdog_hw->scratch[0] = 0x1A17C0DEu;
-        printf("INIT: resetting in %d ms (SYSRESETREQ, flash quiesced)\n", (int) INITIALIZE_REBOOT_DELAY_MS);
-        busy_wait_ms(INITIALIZE_REBOOT_DELAY_MS);
-        low_flash_quiesce();
-        printf("INIT: flash quiesced, SYSRESETREQ now\n");
-        __asm volatile("dsb sy" ::: "memory");
-        scb_hw->aircr = (0x05FAu << M33_AIRCR_VECTKEY_LSB)
-                        | M33_AIRCR_SYSRESETREQ_BITS | M33_AIRCR_SYSRESETREQS_BITS;
-        __asm volatile("dsb sy" ::: "memory");
-        /* If the reset took this is unreachable. Give it 2 s, then STAY ALIVE: the watchdog
-         * fallback was considered and rejected — it is a measured wedge vector, and an alive
-         * card that reports an error beats a card that needs a datacenter visit. Release the
-         * flash mutex so the card keeps working. */
-        busy_wait_ms(2000);
-        low_flash_unquiesce();
-        printf("INIT: ERROR SYSRESETREQ did not reset — staying alive\n");
-        return SW_EXEC_ERROR();
+        /* The reset must NOT fire from inside this handler: the APDU response is only
+         * transmitted after cmd_initialize() returns (apdu_finish on core0), so a reset
+         * executed here lands BEFORE the response — the host watches the card vanish
+         * mid-command and reports Transmit failed (measured 2026-08-02; the old
+         * watchdog_reboot(0,0,500) masked this by being asynchronous). Schedule the
+         * reset instead: return now, the response goes out, and card_watchdog_task()
+         * fires it from core0's loop INITIALIZE_REBOOT_DELAY_MS later. */
+        printf("INIT: scheduling SYSRESETREQ in %d ms\n", (int) INITIALIZE_REBOOT_DELAY_MS);
+        schedule_chip_reset(INITIALIZE_REBOOT_DELAY_MS);
 #endif
     }
     else {   //free memory bytes request

--- a/src/hsm/cmd_initialize.c
+++ b/src/hsm/cmd_initialize.c
@@ -25,6 +25,20 @@
 #include "cvc.h"
 #include "otp.h"
 #include "object_authorization.h"
+#include "usb.h"
+#ifdef PICO_PLATFORM
+#include "hardware/watchdog.h"
+#endif
+
+/* Upper bound on waiting for the re-personalisation write to become durable before the reset
+ * below. Generous on purpose: a full-region erase is many sectors, and overshooting merely
+ * costs a few idle milliseconds, whereas undershooting falls back to the async commit and
+ * reintroduces the race the synchronous wait exists to remove. */
+#define FLASH_COMMIT_SYNC_TIMEOUT_MS 10000
+
+/* Grace period between arming the reset and it firing, so core 0 can transmit the APDU response
+ * first. Without it the host reports "Card removed" for a command that actually succeeded. */
+#define INITIALIZE_REBOOT_DELAY_MS 500
 
 extern char __StackLimit;
 static int heapLeft(void) {
@@ -260,8 +274,42 @@ int cmd_initialize(void) {
         if (ret != PICOKEYS_OK) {
             return SW_EXEC_ERROR();
         }
-        flash_commit();
+        /* Persist SYNCHRONOUSLY. flash_commit() only queues the write for low_flash_task() on
+         * core 0; resetting straight after it would race the write and could leave a
+         * half-written file system. APDU handlers run on core 1, which is exactly where
+         * flash_commit_sync() is usable (it refuses on core 0, since core 0 owns the task it
+         * would be waiting for). Fall back to the async commit if it reports failure so a
+         * timeout can never leave the commit unqueued. */
+        if (!flash_commit_sync(FLASH_COMMIT_SYNC_TIMEOUT_MS)) {
+            flash_commit();
+        }
         reset_puk_store();
+#if defined(PICO_PLATFORM)
+        /* Re-personalising wipes the file system, and the card does NOT come back on its own
+         * afterwards: the reader keeps reporting a card, but the card returns no ATR and
+         * PKCS#11 sees no token, until the firmware rebuilds its state at boot. Before this
+         * reset the only recovery was PHYSICALLY REPLUGGING the device, which is impossible in
+         * a remote or datacenter deployment.
+         *
+         * Resetting after re-personalisation is also what a real smartcard does, so this makes
+         * the Pico behave more like the SmartCard-HSM it stands in for, not less.
+         *
+         * Use watchdog_reboot() and NOT the EV_RESET path. EV_RESET routes to
+         * usb_secure_reboot_now(), which zeroes heap and stack before resetting; that was tried
+         * here first and MEASURED to hang the device outright on RP2350 — it left the bus and
+         * never re-enumerated, recoverable only by physically replugging, i.e. strictly worse
+         * than the bug being fixed. The flash and the wipe were both fine (the card came back
+         * correctly re-personalised after a replug), so the fault is in that reboot path, not
+         * in the commit above. rescue.c:490 already reboots with a plain watchdog_reset for
+         * "reboot to normal mode", which is the proven path in this codebase.
+         *
+         * Not scrubbing RAM first is acceptable: a reset exposes memory to nobody without
+         * physical access to the device, and the alternative here does not reboot at all.
+         *
+         * The delay lets core 0 finish transmitting the APDU response before the reset lands,
+         * so the host sees this command SUCCEED rather than "Card removed". */
+        watchdog_reboot(0, 0, INITIALIZE_REBOOT_DELAY_MS);
+#endif
     }
     else {   //free memory bytes request
         int heap_left = heapLeft();

--- a/src/hsm/cmd_initialize.c
+++ b/src/hsm/cmd_initialize.c
@@ -320,12 +320,18 @@ int cmd_initialize(void) {
          * The delay lets core 0 finish transmitting the APDU response before the reset lands,
          * so the host sees this command SUCCEED rather than "Card removed".
          *
-         * MEASURED RELIABILITY: 7/7 on a warm device, all recovering in ~3s. The single observed
-         * failure was the FIRST initialize after a firmware flash, which hung and needed a
-         * physical replug. One data point is a hypothesis, not a pattern — hsm-cycle-test.sh
-         * exists to settle it. Until it is settled, provisioning should reboot the device (via
-         * the rescue app: SELECT AID then 80 1F 00 00) after flashing and BEFORE the first
-         * initialize, which avoids the cold path entirely. */
+         * MEASURED RELIABILITY: 9/9 recovering in 1-2s (hsm-cycle-test.sh), INCLUDING the first
+         * initialize after a firmware flash.
+         *
+         * An earlier round measured 7/7 warm but 1/1 HUNG on that first-after-flash case, and it
+         * was very nearly written up as a real cold-boot defect. It was not. The firmware had
+         * been built with -DPICO_BOARD=pico2, i.e. for RP2350A with a 4MB flash map, on a board
+         * that is RP2350B with 16MB (see waveshare_rp2350_pizero.h). Rebuilding against the
+         * correct board definition made the cold path pass first try and every try after.
+         *
+         * BUILD FOR THE ACTUAL BOARD. A generic -DPICO_BOARD target that merely boots is not
+         * evidence it is correct: everything worked well enough to mask the mismatch until one
+         * flash-heavy path failed intermittently. */
         printf("INIT: arming watchdog reset in %d ms\n", (int) INITIALIZE_REBOOT_DELAY_MS);
         watchdog_reboot(0, 0, INITIALIZE_REBOOT_DELAY_MS);
         /* If the UART shows this line and the device never comes back, the watchdog was armed

--- a/src/hsm/cmd_initialize.c
+++ b/src/hsm/cmd_initialize.c
@@ -26,6 +26,7 @@
 #include "otp.h"
 #include "object_authorization.h"
 #include "usb.h"
+#include <stdio.h>
 #ifdef PICO_PLATFORM
 #include "hardware/watchdog.h"
 #endif
@@ -280,10 +281,20 @@ int cmd_initialize(void) {
          * flash_commit_sync() is usable (it refuses on core 0, since core 0 owns the task it
          * would be waiting for). Fall back to the async commit if it reports failure so a
          * timeout can never leave the commit unqueued. */
-        if (!flash_commit_sync(FLASH_COMMIT_SYNC_TIMEOUT_MS)) {
+        /* These printf()s go to the UART (PICO_STDIO_UART is on by default; PICO_STDIO_USB is
+         * not), which is the ONLY channel that survives the failure being chased here: when the
+         * reset below hangs, the device leaves the USB bus, so anything logging over USB goes
+         * dark at exactly the moment it is needed. A serial adapter on GPIO0/GND at 115200
+         * turns "it hung, unclear where" into a line number. */
+        printf("INIT: wipe done, committing flash synchronously\n");
+        bool committed = flash_commit_sync(FLASH_COMMIT_SYNC_TIMEOUT_MS);
+        if (!committed) {
+            printf("INIT: WARN sync commit reported failure, falling back to async\n");
             flash_commit();
         }
+        printf("INIT: flash committed (sync=%d)\n", (int) committed);
         reset_puk_store();
+        printf("INIT: puk store reset\n");
 #if defined(PICO_PLATFORM)
         /* Re-personalising wipes the file system, and the card does NOT come back on its own
          * afterwards: the reader keeps reporting a card, but the card returns no ATR and
@@ -307,8 +318,21 @@ int cmd_initialize(void) {
          * physical access to the device, and the alternative here does not reboot at all.
          *
          * The delay lets core 0 finish transmitting the APDU response before the reset lands,
-         * so the host sees this command SUCCEED rather than "Card removed". */
+         * so the host sees this command SUCCEED rather than "Card removed".
+         *
+         * MEASURED RELIABILITY: 7/7 on a warm device, all recovering in ~3s. The single observed
+         * failure was the FIRST initialize after a firmware flash, which hung and needed a
+         * physical replug. One data point is a hypothesis, not a pattern — hsm-cycle-test.sh
+         * exists to settle it. Until it is settled, provisioning should reboot the device (via
+         * the rescue app: SELECT AID then 80 1F 00 00) after flashing and BEFORE the first
+         * initialize, which avoids the cold path entirely. */
+        printf("INIT: arming watchdog reset in %d ms\n", (int) INITIALIZE_REBOOT_DELAY_MS);
         watchdog_reboot(0, 0, INITIALIZE_REBOOT_DELAY_MS);
+        /* If the UART shows this line and the device never comes back, the watchdog was armed
+         * and the fault is in the reset/re-enumeration itself. If it never appears, the hang is
+         * EARLIER — in the commit or the wipe — and the lines above localise it. That
+         * distinction is the whole reason these logs exist. */
+        printf("INIT: watchdog armed, returning SW_OK\n");
 #endif
     }
     else {   //free memory bytes request

--- a/src/hsm/cmd_initialize.c
+++ b/src/hsm/cmd_initialize.c
@@ -29,6 +29,8 @@
 #include <stdio.h>
 #ifdef PICO_PLATFORM
 #include "hardware/watchdog.h"
+#include "hardware/structs/scb.h"
+#include "pico/time.h"
 #endif
 
 /* Upper bound on waiting for the re-personalisation write to become durable before the reset
@@ -326,40 +328,49 @@ int cmd_initialize(void) {
          * Resetting after re-personalisation is also what a real smartcard does, so this makes
          * the Pico behave more like the SmartCard-HSM it stands in for, not less.
          *
-         * Use watchdog_reboot() and NOT the EV_RESET path. EV_RESET routes to
-         * usb_secure_reboot_now(), which zeroes heap and stack before resetting; that was tried
-         * here first and MEASURED to hang the device outright on RP2350 — it left the bus and
-         * never re-enumerated, recoverable only by physically replugging, i.e. strictly worse
-         * than the bug being fixed. The flash and the wipe were both fine (the card came back
-         * correctly re-personalised after a replug), so the fault is in that reboot path, not
-         * in the commit above. rescue.c:490 already reboots with a plain watchdog_reset for
-         * "reboot to normal mode", which is the proven path in this codebase.
+         * Do NOT use the EV_RESET path: it routes to usb_secure_reboot_now(), which zeroes
+         * heap and stack before resetting; that was tried here first and MEASURED to hang the
+         * device outright on RP2350 — it left the bus and never re-enumerated, recoverable only
+         * by physically replugging, i.e. strictly worse than the bug being fixed.
+         *
+         * THE MEASURED HISTORY OF THIS RESET (2026-08-02, Debug Probe on SWD, xPack OpenOCD
+         * rp2350 target, hsm-cycle-test.sh, all on a populated card):
+         *   - watchdog_reboot(): ~7% of cycles HUNG — device left the USB bus, never
+         *     re-enumerated. SWD forensics on the live hang: watchdog REASON.TIMER set (the
+         *     watchdog DID fire), both cores reading all-zero, XIP SSI all-zero, bootram
+         *     diagnostics untouched — the post-reset boot never got as far as XIP setup.
+         *   - AIRCR.SYSRESETREQS alone: 13 clean cycles, then the SAME hang. NOTE: this round
+         *     is unattributable — a watchdog fallback fired if the AIRCR write didn't take, and
+         *     OpenOCD flashing pollutes REASON, so which reset actually ran is unknown.
+         *   - Flash quiesce (mtx_flash held) + SYSRESETREQS: 10 clean cycles, SAME hang.
+         * Whatever wedges the warm boot, it is NOT cleanly the reset type and NOT cleanly
+         * flash-busy-at-reset. The quiesce is kept (it is cheap and removes one variable); the
+         * watchdog fallback is REMOVED so an AIRCR failure reads as "declined but alive"
+         * instead of another wedge; and scratch[0] carries an attribution marker so the next
+         * hang can be tied to the exact code path that preceded it.
          *
          * Not scrubbing RAM first is acceptable: a reset exposes memory to nobody without
-         * physical access to the device, and the alternative here does not reboot at all.
-         *
-         * The delay lets core 0 finish transmitting the APDU response before the reset lands,
-         * so the host sees this command SUCCEED rather than "Card removed".
-         *
-         * MEASURED RELIABILITY: 9/9 recovering in 1-2s (hsm-cycle-test.sh), INCLUDING the first
-         * initialize after a firmware flash.
-         *
-         * An earlier round measured 7/7 warm but 1/1 HUNG on that first-after-flash case, and it
-         * was very nearly written up as a real cold-boot defect. It was not. The firmware had
-         * been built with -DPICO_BOARD=pico2, i.e. for RP2350A with a 4MB flash map, on a board
-         * that is RP2350B with 16MB (see waveshare_rp2350_pizero.h). Rebuilding against the
-         * correct board definition made the cold path pass first try and every try after.
-         *
-         * BUILD FOR THE ACTUAL BOARD. A generic -DPICO_BOARD target that merely boots is not
-         * evidence it is correct: everything worked well enough to mask the mismatch until one
-         * flash-heavy path failed intermittently. */
-        printf("INIT: arming watchdog reset in %d ms\n", (int) INITIALIZE_REBOOT_DELAY_MS);
-        watchdog_reboot(0, 0, INITIALIZE_REBOOT_DELAY_MS);
-        /* If the UART shows this line and the device never comes back, the watchdog was armed
-         * and the fault is in the reset/re-enumeration itself. If it never appears, the hang is
-         * EARLIER — in the commit or the wipe — and the lines above localise it. That
-         * distinction is the whole reason these logs exist. */
-        printf("INIT: watchdog armed, returning SW_OK\n");
+         * physical access to the device. */
+        /* Attribution marker for SWD forensics: scratch registers survive warm resets, so a
+         * hang found with this marker present means THIS build reset and wedged afterwards;
+         * absent means the wedge predates the current firmware. */
+        watchdog_hw->scratch[0] = 0x1A17C0DEu;
+        printf("INIT: resetting in %d ms (SYSRESETREQ, flash quiesced)\n", (int) INITIALIZE_REBOOT_DELAY_MS);
+        busy_wait_ms(INITIALIZE_REBOOT_DELAY_MS);
+        low_flash_quiesce();
+        printf("INIT: flash quiesced, SYSRESETREQ now\n");
+        __asm volatile("dsb sy" ::: "memory");
+        scb_hw->aircr = (0x05FAu << M33_AIRCR_VECTKEY_LSB)
+                        | M33_AIRCR_SYSRESETREQ_BITS | M33_AIRCR_SYSRESETREQS_BITS;
+        __asm volatile("dsb sy" ::: "memory");
+        /* If the reset took this is unreachable. Give it 2 s, then STAY ALIVE: the watchdog
+         * fallback was considered and rejected — it is a measured wedge vector, and an alive
+         * card that reports an error beats a card that needs a datacenter visit. Release the
+         * flash mutex so the card keeps working. */
+        busy_wait_ms(2000);
+        low_flash_unquiesce();
+        printf("INIT: ERROR SYSRESETREQ did not reset — staying alive\n");
+        return SW_EXEC_ERROR();
 #endif
     }
     else {   //free memory bytes request

--- a/tools/hsm-cycle-test.sh
+++ b/tools/hsm-cycle-test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# hsm-cycle-test.sh — measure how reliably a Pico HSM survives re-provisioning.
+#
+#   ./hsm-cycle-test.sh --cycles 10
+#   ./hsm-cycle-test.sh --cycles 5 --uart /dev/tty.usbserial-0001    # capture firmware logs
+#   ./hsm-cycle-test.sh --cycles 3 --full                            # whole chain, not just reset
+#
+# WHY THIS EXISTS. `sc-hsm-tool --initialize` re-personalises the device, and the firmware resets
+# itself afterwards so the card can rebuild state (without that reset the card never comes back
+# and only a PHYSICAL REPLUG recovers it). That reset was measured at 7/7 on a warm device and
+# 1/1 HUNG on the first initialize after a firmware flash — a real difference on a tiny sample.
+# Settling that needs repetition with consistent instrumentation, which is what this is.
+#
+# INSTRUMENTATION NOTES, all learned by getting them wrong first:
+#   - Presence is read from the USB layer, NOT from `opensc-tool --list-readers`. That call costs
+#     ~1s, and the reset completes in ~1-3s, so polling with it MISSES the gap and reports a
+#     successful reset as "never rebooted".
+#   - A reboot is detected by the device IDENTITY CHANGING, not by observing an absence. Racing a
+#     ~1s absence window produces false negatives; a new identity is durable evidence.
+#   - Exit codes are read directly, never through a pipe. `cmd | tail` yields tail's status, which
+#     silently turns a failure into a pass.
+set -u
+
+CYCLES=5
+UART=""
+FULL=0
+SO_PIN="${HSM_SO_PIN:-3537363231383830}"
+USER_PIN="${HSM_USER_PIN:-648219}"
+STAGING="${HSM_STAGING_DIR:-$HOME/.local/share/akash-hsm-staging}"
+VIDPID="2e8a:10fd"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cycles) CYCLES="$2"; shift 2;;
+        --uart)   UART="$2"; shift 2;;
+        --full)   FULL=1; shift;;
+        -h|--help) sed -n '2,30p' "$0"; exit 0;;
+        *) echo "unknown arg: $1" >&2; exit 2;;
+    esac
+done
+
+# Device identity, cheaply, on whichever platform. It only has to CHANGE across a re-enumeration;
+# its actual value is meaningless. On Linux the bus/device number is reassigned on reconnect; on
+# macOS the IORegistry entry id is.
+device_id() {
+    case "$(uname -s)" in
+        Darwin) ioreg -p IOUSB -w0 2>/dev/null | grep -i "pico" | grep -oE "id 0x[0-9a-f]+" | head -1;;
+        Linux)  lsusb -d "$VIDPID" 2>/dev/null | head -1 | awk '{print $2"/"$4}';;
+        *)      echo "unsupported platform: $(uname -s)" >&2; exit 2;;
+    esac
+}
+
+card_responds() {
+    perl -e 'alarm 30; exec @ARGV' -- sc-hsm-tool >/dev/null 2>&1
+}
+
+# Wait for a NEW identity, i.e. the device re-enumerated. Returns 0 with SECS set, else 1.
+SECS=0
+wait_for_new_id() {
+    local before="$1" limit="${2:-45}" waited=0 now
+    while [ "$waited" -lt "$limit" ]; do
+        sleep 1; waited=$((waited + 1))
+        now="$(device_id)"
+        if [ -n "$now" ] && [ "$now" != "$before" ]; then SECS=$waited; return 0; fi
+    done
+    SECS=$waited; return 1
+}
+
+start_uart_capture() {
+    [ -n "$UART" ] || return 0
+    [ -e "$UART" ] || { echo "  ! UART $UART not present, continuing without logs" >&2; UART=""; return 0; }
+    # Raw read in the background. cat is enough: we only ever want to see what the firmware said,
+    # never to write to it.
+    ( stty -f "$UART" 115200 raw 2>/dev/null || stty -F "$UART" 115200 raw 2>/dev/null ) || true
+    cat "$UART" > "$LOGDIR/uart-cycle-$1.log" 2>/dev/null &
+    UART_PID=$!
+}
+
+stop_uart_capture() {
+    [ -n "${UART_PID:-}" ] || return 0
+    kill "$UART_PID" 2>/dev/null; wait "$UART_PID" 2>/dev/null
+    UART_PID=""
+}
+
+LOGDIR="$(mktemp -d)"
+echo "logs: $LOGDIR"
+[ -n "$UART" ] && echo "uart: $UART (115200)"
+echo "cycles: $CYCLES  mode: $([ "$FULL" = 1 ] && echo full-chain || echo reset-only)"
+echo
+
+if [ -z "$(device_id)" ]; then
+    echo "no Pico HSM on the bus ($VIDPID) — plug it in first" >&2
+    exit 1
+fi
+
+pass=0; fail=0; times=""
+for n in $(seq 1 "$CYCLES"); do
+    printf 'cycle %s/%s: ' "$n" "$CYCLES"
+    start_uart_capture "$n"
+    before="$(device_id)"
+
+    perl -e 'alarm 180; exec @ARGV' -- sc-hsm-tool --initialize \
+        --so-pin "$SO_PIN" --pin "$USER_PIN" --dkek-shares 1 --label "cycle$n" \
+        < /dev/null > "$LOGDIR/init-$n.log" 2>&1
+    init_rc=$?
+
+    if wait_for_new_id "$before" 45; then
+        # Re-enumerating is necessary but not sufficient — the card must actually answer.
+        settled=0
+        for _ in $(seq 1 15); do
+            sleep 1
+            if card_responds; then settled=1; break; fi
+        done
+        if [ "$settled" = 1 ]; then
+            pass=$((pass + 1)); times="$times $SECS"
+            echo "RECOVERED in ${SECS}s (init rc=$init_rc)"
+        else
+            fail=$((fail + 1))
+            echo "REBOOTED but card never answered — partial failure"
+        fi
+    else
+        fail=$((fail + 1))
+        echo "HUNG — no re-enumeration in ${SECS}s. NEEDS A PHYSICAL REPLUG; stopping."
+        stop_uart_capture
+        [ -n "$UART" ] && echo "  firmware log: $LOGDIR/uart-cycle-$n.log"
+        break
+    fi
+    stop_uart_capture
+
+    if [ "$FULL" = 1 ]; then
+        if [ -f "$STAGING/dkek.pbe" ] && [ -f "$STAGING/dkek.pw" ]; then
+            DKEK_PW="$(cat "$STAGING/dkek.pw")" perl -e 'alarm 120; exec @ARGV' -- \
+                sc-hsm-tool --import-dkek-share "$STAGING/dkek.pbe" \
+                --password env:DKEK_PW --so-pin "$SO_PIN" < /dev/null \
+                > "$LOGDIR/dkek-$n.log" 2>&1
+            echo "  dkek import rc=$?"
+        else
+            echo "  ! no DKEK share in $STAGING — skipping full chain"
+        fi
+    fi
+done
+
+echo
+echo "==================================================="
+echo " passed: $pass    hung: $fail    of $((pass + fail)) attempted"
+[ -n "$times" ] && echo " recovery times:$times (seconds)"
+echo " logs: $LOGDIR"
+echo "==================================================="
+[ "$fail" -eq 0 ] || exit 1

--- a/tools/hsm-cycle-test.sh
+++ b/tools/hsm-cycle-test.sh
@@ -28,6 +28,9 @@ SO_PIN="${HSM_SO_PIN:-3537363231383830}"
 USER_PIN="${HSM_USER_PIN:-648219}"
 STAGING="${HSM_STAGING_DIR:-$HOME/.local/share/akash-hsm-staging}"
 VIDPID="2e8a:10fd"
+AUTO_IMPORT="${HSM_AUTO_IMPORT:-$HOME/code/Akash-Console-hsmfix/infra/ceremony/qubes/scripts/hsm-auto-import.sh}"
+VERIFY="${HSM_VERIFY:-$HOME/code/Akash-Console-hsmfix/infra/ceremony/qubes/scripts/verify-hsm-control.py}"
+P11MOD="${HSM_PKCS11_MODULE:-/opt/homebrew/lib/opensc-pkcs11.so}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -93,7 +96,7 @@ if [ -z "$(device_id)" ]; then
     exit 1
 fi
 
-pass=0; fail=0; times=""
+pass=0; fail=0; declined=0; times=""; chain_pass=0; chain_fail=0
 for n in $(seq 1 "$CYCLES"); do
     printf 'cycle %s/%s: ' "$n" "$CYCLES"
     start_uart_capture "$n"
@@ -119,31 +122,94 @@ for n in $(seq 1 "$CYCLES"); do
             echo "REBOOTED but card never answered — partial failure"
         fi
     else
-        fail=$((fail + 1))
-        echo "HUNG — no re-enumeration in ${SECS}s. NEEDS A PHYSICAL REPLUG; stopping."
+        # "No re-enumeration" has TWO causes and they are opposites. The firmware declines to
+        # reset when the flash commit is unconfirmed (returning SW_EXEC_ERROR and staying alive
+        # on purpose, since an operator who can retry beats a device needing a datacenter visit).
+        # That also produces no new identity — but the device is FINE. Calling it a hang would
+        # report the safety mechanism working as a failure, so distinguish them by whether the
+        # device is still on the bus.
         stop_uart_capture
-        [ -n "$UART" ] && echo "  firmware log: $LOGDIR/uart-cycle-$n.log"
+        if [ -n "$(device_id)" ]; then
+            echo "DECLINED to reset but device is ALIVE (init rc=$init_rc) — commit was"
+            echo "         unconfirmed and the firmware correctly refused to reset. Retryable."
+            declined=$((declined + 1))
+        else
+            fail=$((fail + 1))
+            echo "HUNG — gone from the bus after ${SECS}s. NEEDS A PHYSICAL REPLUG; stopping."
+            [ -n "$UART" ] && echo "  firmware log: $LOGDIR/uart-cycle-$n.log"
+        fi
         break
     fi
     stop_uart_capture
 
     if [ "$FULL" = 1 ]; then
-        if [ -f "$STAGING/dkek.pbe" ] && [ -f "$STAGING/dkek.pw" ]; then
+        # The whole point of --full: assert CRYPTO CORRECTNESS every cycle, not just that the
+        # device came back. Re-provisioning that reliably produces the WRONG key would pass a
+        # reset-only test forever, and would lose funds in production. So each cycle re-imports
+        # the seed-derived key and proves the card signs for the seed's public key — plus a
+        # negative control, so a verifier that trivially returns success cannot fake a pass.
+        chain_ok=1
+        if [ ! -f "$STAGING/dkek.pbe" ] || [ ! -f "$STAGING/dkek.pw" ]; then
+            echo "  ! no DKEK share in $STAGING — cannot run the chain"; chain_ok=0
+        elif [ ! -x "$AUTO_IMPORT" ]; then
+            echo "  ! auto-import script not found at $AUTO_IMPORT (set HSM_AUTO_IMPORT)"; chain_ok=0
+        fi
+
+        if [ "$chain_ok" = 1 ]; then
             DKEK_PW="$(cat "$STAGING/dkek.pw")" perl -e 'alarm 120; exec @ARGV' -- \
                 sc-hsm-tool --import-dkek-share "$STAGING/dkek.pbe" \
                 --password env:DKEK_PW --so-pin "$SO_PIN" < /dev/null \
-                > "$LOGDIR/dkek-$n.log" 2>&1
-            echo "  dkek import rc=$?"
+                > "$LOGDIR/dkek-$n.log" 2>&1 || chain_ok=0
+            [ "$chain_ok" = 1 ] || echo "  CHAIN FAIL: dkek import"
+        fi
+
+        if [ "$chain_ok" = 1 ]; then
+            HSM_AUTO_DIR="$STAGING/auto-import" SCSH_HOME="${SCSH_HOME:-$HOME/tools/scsh-3.18.77}" \
+            HSM_USER_PIN="$USER_PIN" HSM_DKEK_SHARE_IN="$STAGING/dkek.pbe" \
+            HSM_DKEK_PW_IN="$STAGING/dkek.pw" \
+                perl -e 'alarm 300; exec @ARGV' -- "$AUTO_IMPORT" --run \
+                > "$LOGDIR/import-$n.log" 2>&1 || chain_ok=0
+            [ "$chain_ok" = 1 ] || echo "  CHAIN FAIL: key import (see $LOGDIR/import-$n.log)"
+        fi
+
+        if [ "$chain_ok" = 1 ]; then
+            head -c 32 /dev/urandom > "$LOGDIR/d-$n.bin"
+            pkcs11-tool --module "$P11MOD" --login --pin "$USER_PIN" --sign --mechanism ECDSA \
+                --id 31 --input-file "$LOGDIR/d-$n.bin" --output-file "$LOGDIR/s-$n.bin" \
+                > "$LOGDIR/sign-$n.log" 2>&1 || chain_ok=0
+            if [ "$chain_ok" = 1 ]; then
+                python3 "$VERIFY" --der "$STAGING/expected-pub.der" \
+                    --digest "$LOGDIR/d-$n.bin" --sig "$LOGDIR/s-$n.bin" >/dev/null 2>&1
+                if [ $? -ne 0 ]; then
+                    chain_ok=0; echo "  CHAIN FAIL: card signature does NOT match the seed's pubkey"
+                else
+                    # Negative control: the same signature against a DIFFERENT digest must FAIL.
+                    # Without this, a verifier stuck returning 0 would make every cycle "pass".
+                    head -c 32 /dev/urandom > "$LOGDIR/dbad-$n.bin"
+                    python3 "$VERIFY" --der "$STAGING/expected-pub.der" \
+                        --digest "$LOGDIR/dbad-$n.bin" --sig "$LOGDIR/s-$n.bin" >/dev/null 2>&1
+                    if [ $? -eq 0 ]; then
+                        chain_ok=0; echo "  CHAIN FAIL: negative control PASSED — verifier is not discriminating"
+                    fi
+                fi
+            else
+                echo "  CHAIN FAIL: on-card signing"
+            fi
+        fi
+
+        if [ "$chain_ok" = 1 ]; then
+            chain_pass=$((chain_pass + 1)); echo "  chain OK (key imported, signed, verified, negative control held)"
         else
-            echo "  ! no DKEK share in $STAGING — skipping full chain"
+            chain_fail=$((chain_fail + 1))
         fi
     fi
 done
 
 echo
 echo "==================================================="
-echo " passed: $pass    hung: $fail    of $((pass + fail)) attempted"
+echo " passed: $pass    hung: $fail    declined-safely: $declined    of $((pass + fail + declined)) attempted"
 [ -n "$times" ] && echo " recovery times:$times (seconds)"
+[ "$FULL" = 1 ] && echo " full chain: $chain_pass verified, $chain_fail failed"
 echo " logs: $LOGDIR"
 echo "==================================================="
-[ "$fail" -eq 0 ] || exit 1
+[ "$fail" -eq 0 ] && [ "${chain_fail:-0}" -eq 0 ] || exit 1

--- a/tools/hsm-scenarios.sh
+++ b/tools/hsm-scenarios.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# hsm-scenarios.sh — exercise a STAGING Pico HSM across scenarios the happy path never touches.
+#
+#   ./hsm-scenarios.sh              # all scenarios
+#   ./hsm-scenarios.sh S1 S4        # only the named ones
+#
+# The provisioning soak (hsm-cycle-test.sh) proves the operational happy path: wipe, rebuild the
+# DKEK domain, import a seed-derived key, sign, verify. Passing that 14 times says nothing about
+# whether the device REFUSES what it should, how fast it is, or how it behaves when something goes
+# wrong — and those are the properties an HSM is actually bought for.
+#
+# NEVER RUN THIS AGAINST A DEVICE HOLDING REAL KEYS. Several scenarios deliberately wipe the card,
+# spend PIN attempts, and attempt operations that must fail.
+set -u
+
+SO_PIN="${HSM_SO_PIN:-3537363231383830}"
+USER_PIN="${HSM_USER_PIN:-648219}"
+STAGING="${HSM_STAGING_DIR:-$HOME/.local/share/akash-hsm-staging}"
+AUTO_IMPORT="${HSM_AUTO_IMPORT:-$HOME/code/Akash-Console-hsmfix/infra/ceremony/qubes/scripts/hsm-auto-import.sh}"
+VERIFY="${HSM_VERIFY:-$HOME/code/Akash-Console-hsmfix/infra/ceremony/qubes/scripts/verify-hsm-control.py}"
+P11="${HSM_PKCS11_MODULE:-/opt/homebrew/lib/opensc-pkcs11.so}"
+SCSH="${SCSH_HOME:-$HOME/tools/scsh-3.18.77}"
+WORK="$(mktemp -d)"
+WANT="$*"
+
+pass=0; fail=0; skip=0
+P() { printf '  \033[32mPASS\033[0m %s\n' "$1"; pass=$((pass+1)); }
+F() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail+1)); }
+S() { printf '  \033[33mSKIP\033[0m %s\n' "$1"; skip=$((skip+1)); }
+hdr() { printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+want() { [ -z "$WANT" ] || case " $WANT " in *" $1 "*) return 0;; *) return 1;; esac; }
+
+t() { perl -e "alarm ${2:-60}; exec @ARGV" -- ${1}; }   # bounded run
+card_alive() { perl -e 'alarm 30; exec @ARGV' -- sc-hsm-tool >/dev/null 2>&1; }
+
+wipe_and_provision() {
+    perl -e 'alarm 200; exec @ARGV' -- sc-hsm-tool --initialize --so-pin "$SO_PIN" --pin "$USER_PIN" \
+        --dkek-shares 1 --label scen < /dev/null >/dev/null 2>&1 || return 1
+    for _ in $(seq 1 40); do sleep 1; card_alive && break; done
+    card_alive || return 1
+    DKEK_PW="$(cat "$STAGING/dkek.pw")" perl -e 'alarm 120; exec @ARGV' -- \
+        sc-hsm-tool --import-dkek-share "$STAGING/dkek.pbe" --password env:DKEK_PW \
+        --so-pin "$SO_PIN" < /dev/null >/dev/null 2>&1 || return 1
+    HSM_AUTO_DIR="$STAGING/auto-import" SCSH_HOME="$SCSH" HSM_USER_PIN="$USER_PIN" \
+    HSM_DKEK_SHARE_IN="$STAGING/dkek.pbe" HSM_DKEK_PW_IN="$STAGING/dkek.pw" \
+        perl -e 'alarm 300; exec @ARGV' -- "$AUTO_IMPORT" --run >"$WORK/prov.log" 2>&1
+}
+
+sign_and_verify() {   # $1 = key id
+    head -c 32 /dev/urandom > "$WORK/d.bin"
+    pkcs11-tool --module "$P11" --login --pin "$USER_PIN" --sign --mechanism ECDSA \
+        --id "$1" --input-file "$WORK/d.bin" --output-file "$WORK/s.bin" >/dev/null 2>&1 || return 1
+    python3 "$VERIFY" --der "$STAGING/expected-pub.der" --digest "$WORK/d.bin" --sig "$WORK/s.bin" >/dev/null 2>&1
+}
+
+echo "workdir: $WORK"
+card_alive || { echo "card not responding — replug and flash COMMITFIX first" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------------------------
+if want S1; then
+hdr "S1  SECURITY: a key wrapped under a DIFFERENT DKEK must be REFUSED"
+# THE test for the fleet model. Cloning to a second device is only safe because a card that does
+# not share the DKEK domain CANNOT unwrap the blob. That has been asserted all along and only ever
+# checked in an emulator whose own header admits it cannot prove the real path. If this ever
+# silently SUCCEEDS, the DKEK provides no isolation and the fleet design is unsound.
+if wipe_and_provision; then
+    ( umask 077; LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32 > "$WORK/bad.pw" )
+    DKEK_PW="$(cat "$WORK/bad.pw")" sc-hsm-tool --create-dkek-share "$WORK/bad.pbe" \
+        --password env:DKEK_PW >/dev/null 2>&1
+    if [ -s "$WORK/bad.pbe" ]; then
+        # Wrap under the FOREIGN share while the card still holds the original domain.
+        HSM_AUTO_DIR="$WORK/foreign" SCSH_HOME="$SCSH" HSM_USER_PIN="$USER_PIN" \
+        HSM_DKEK_SHARE_IN="$WORK/bad.pbe" HSM_DKEK_PW_IN="$WORK/bad.pw" \
+            perl -e 'alarm 300; exec @ARGV' -- "$AUTO_IMPORT" --run > "$WORK/foreign.log" 2>&1
+        rc=$?
+        if [ $rc -eq 0 ] && grep -q "IMPORT-OK" "$WORK/foreign.log"; then
+            F "CARD ACCEPTED A FOREIGN-DKEK KEY — DKEK provides no isolation (SECURITY)"
+        else
+            P "foreign-DKEK key refused (rc=$rc, no IMPORT-OK)"
+        fi
+    else
+        S "could not create a second DKEK share"
+    fi
+else
+    S "S1: provisioning failed, cannot set up"
+fi
+fi
+
+# ---------------------------------------------------------------------------------------------
+if want S2; then
+hdr "S2  THROUGHPUT: how many signatures per second?"
+# The quorum flagged throughput as a production concern for an always-on signing oracle and nobody
+# ever measured it. A number beats an opinion.
+if card_alive && sign_and_verify 31; then
+    N=20; t0=$(python3 -c 'import time;print(time.time())')
+    ok=0
+    for _ in $(seq 1 $N); do sign_and_verify 31 && ok=$((ok+1)); done
+    t1=$(python3 -c 'import time;print(time.time())')
+    python3 - "$t0" "$t1" "$N" "$ok" <<'PY'
+import sys
+t0,t1,n,ok=float(sys.argv[1]),float(sys.argv[2]),int(sys.argv[3]),int(sys.argv[4])
+d=t1-t0
+print(f"  {ok}/{n} signatures verified, {d:.1f}s total, {d/n*1000:.0f} ms/sig, {n/d:.2f} sig/s")
+print("  NOTE: each iteration is a fresh pkcs11-tool process + PIN login, so this is an")
+print("  UPPER BOUND on latency, not the card's raw speed. A persistent session would be faster.")
+PY
+    [ "$ok" = "$N" ] && P "all $N signatures verified under load" || F "only $ok/$N verified"
+else
+    S "S2: no usable key on card"
+fi
+fi
+
+# ---------------------------------------------------------------------------------------------
+if want S3; then
+hdr "S3  SIGNATURE CANONICALITY: low-S, as Cosmos requires"
+# Cosmos REJECTS high-S signatures. tx-signer normalises via toLowSCompact(), but if the card emits
+# high-S at any meaningful rate that normalisation is load-bearing rather than belt-and-braces,
+# and anything that signs without it is broken. Measure the actual rate.
+if card_alive; then
+    high=0; tot=15
+    for _ in $(seq 1 $tot); do
+        head -c 32 /dev/urandom > "$WORK/d.bin"
+        pkcs11-tool --module "$P11" --login --pin "$USER_PIN" --sign --mechanism ECDSA --id 31 \
+            --input-file "$WORK/d.bin" --output-file "$WORK/s.bin" >/dev/null 2>&1 || continue
+        python3 - "$WORK/s.bin" <<'PY' && high=$((high+1))
+import sys
+N=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+sig=open(sys.argv[1],'rb').read()
+s=int.from_bytes(sig[32:64],'big') if len(sig)==64 else 0
+sys.exit(0 if s > N//2 else 1)
+PY
+    done
+    echo "  high-S: $high of $tot signatures"
+    if [ "$high" -gt 0 ]; then
+        P "card DOES emit high-S ($high/$tot) — toLowSCompact() normalisation is REQUIRED, not optional"
+    else
+        P "no high-S observed in $tot (normalisation still required: absence is not a guarantee)"
+    fi
+else
+    S "S3: card not responding"
+fi
+fi
+
+# ---------------------------------------------------------------------------------------------
+if want S4; then
+hdr "S4  WRONG PIN: signing must fail, and retries must decrement then recover"
+# Deliberately spends ONE attempt of three, then immediately verifies with the correct PIN, which
+# resets the counter. Never gets near a lockout.
+if card_alive; then
+    before=$(sc-hsm-tool 2>/dev/null | grep -oE "User PIN tries left *: *[0-9]+" | grep -oE "[0-9]+$")
+    head -c 32 /dev/urandom > "$WORK/d.bin"
+    pkcs11-tool --module "$P11" --login --pin 999999 --sign --mechanism ECDSA --id 31 \
+        --input-file "$WORK/d.bin" --output-file "$WORK/s.bin" >/dev/null 2>&1
+    if [ $? -eq 0 ]; then F "SIGNED WITH A WRONG PIN (SECURITY)"; else P "wrong PIN refused"; fi
+    mid=$(sc-hsm-tool 2>/dev/null | grep -oE "User PIN tries left *: *[0-9]+" | grep -oE "[0-9]+$")
+    [ "${mid:-9}" -lt "${before:-9}" ] && P "retry counter decremented ($before -> $mid)" \
+                                       || F "retry counter did NOT decrement ($before -> $mid)"
+    sign_and_verify 31 >/dev/null 2>&1
+    after=$(sc-hsm-tool 2>/dev/null | grep -oE "User PIN tries left *: *[0-9]+" | grep -oE "[0-9]+$")
+    [ "${after:-0}" -ge "${before:-9}" ] && P "counter restored after a correct PIN ($mid -> $after)" \
+                                        || F "counter NOT restored ($mid -> $after)"
+else
+    S "S4: card not responding"
+fi
+fi
+
+# ---------------------------------------------------------------------------------------------
+if want S5; then
+hdr "S5  PERSISTENCE: the key survives a reboot"
+# Provisioning is worthless if a restart loses the key. Reboot via the rescue app (stock firmware,
+# measured 5/5) and confirm the SAME key still signs for the SAME public key afterwards.
+if card_alive && sign_and_verify 31; then
+    perl -e 'alarm 45; exec @ARGV' -- opensc-tool -s "00:A4:04:00:08:A0:58:3F:C1:9B:7E:4F:21" \
+        -s "80:1F:00:00" >/dev/null 2>&1
+    sleep 3
+    back=0; for _ in $(seq 1 30); do sleep 1; card_alive && { back=1; break; }; done
+    if [ "$back" = 1 ]; then
+        sign_and_verify 31 && P "key survived the reboot and still signs for the seed's pubkey" \
+                           || F "key did NOT verify after reboot"
+    else
+        F "device did not come back from the reboot"
+    fi
+else
+    S "S5: no usable key to test"
+fi
+fi
+
+# ---------------------------------------------------------------------------------------------
+if want S6; then
+hdr "S6  RAPID-FIRE: back-to-back operations without pauses"
+# The soak is leisurely; a real signer is not. Hammer it and see whether anything wedges.
+if card_alive; then
+    ok=0; n=25
+    for _ in $(seq 1 $n); do sign_and_verify 31 && ok=$((ok+1)); done
+    [ "$ok" = "$n" ] && P "$ok/$n rapid signatures verified" || F "only $ok/$n under rapid fire"
+    card_alive && P "card still responsive after the burst" || F "card wedged after the burst"
+else
+    S "S6: card not responding"
+fi
+fi
+
+echo
+echo "==================================================="
+echo " scenarios: $pass passed, $fail failed, $skip skipped"
+echo " workdir: $WORK"
+echo "==================================================="
+[ "$fail" -eq 0 ] || exit 1

--- a/tools/pico-hsm-reset.py
+++ b/tools/pico-hsm-reset.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Reset a Pico HSM over USB, without touching the hardware.
+
+This is the host side of the PICOKEYS_REMOTE_RESET build option. Firmware built WITHOUT that
+option ignores these requests, which is the intended default — see the CMake option for why.
+
+    pico-hsm-reset.py                # reboot into firmware (recovery)
+    pico-hsm-reset.py --bootsel      # reboot into the bootloader (remote firmware update)
+
+Why not picotool: picotool looks for the Pico SDK's dedicated reset interface, identified as
+class 0xFF / subclass 0x00 / protocol 0x01. The Pico HSM's CCID interface is vendor-class but
+protocol 0x00, so picotool does not recognise it. The control request itself is identical; only
+the discovery differs, so a direct control transfer works where picotool does not.
+
+Uses libusb through ctypes on purpose: no pyusb, no pip install, nothing to provision on a
+machine whose only job is to recover a wedged token.
+"""
+import ctypes
+import ctypes.util
+import sys
+import time
+
+VID, PID = 0x2E8A, 0x10FD
+
+# From pico/usb_reset_interface.h. Kept in sync with the firmware, which links the SDK header.
+RESET_REQUEST_BOOTSEL = 0x01
+RESET_REQUEST_FLASH = 0x02
+
+# host->device (0) | vendor (2<<5) | recipient=interface (1)
+BMREQUEST_VENDOR_INTERFACE_OUT = 0x41
+
+
+def _load_libusb():
+    for cand in ("/opt/homebrew/lib/libusb-1.0.dylib", "/usr/local/lib/libusb-1.0.dylib"):
+        try:
+            return ctypes.CDLL(cand)
+        except OSError:
+            pass
+    found = ctypes.util.find_library("usb-1.0")
+    if not found:
+        sys.exit("libusb not found. brew install libusb")
+    return ctypes.CDLL(found)
+
+
+def main() -> int:
+    bootsel = "--bootsel" in sys.argv
+    request = RESET_REQUEST_BOOTSEL if bootsel else RESET_REQUEST_FLASH
+    what = "BOOTSEL (bootloader)" if bootsel else "flash (firmware)"
+
+    lib = _load_libusb()
+    # EVERY signature must be declared. ctypes defaults undeclared integer arguments to C int,
+    # which truncates a 64-bit device handle to 32 bits and segfaults on the next call — it does
+    # not fail cleanly, it crashes. Omitting these is the single easiest way to get this wrong.
+    lib.libusb_init.argtypes = [ctypes.c_void_p]
+    lib.libusb_exit.argtypes = [ctypes.c_void_p]
+    lib.libusb_open_device_with_vid_pid.argtypes = [ctypes.c_void_p, ctypes.c_uint16, ctypes.c_uint16]
+    lib.libusb_open_device_with_vid_pid.restype = ctypes.c_void_p
+    lib.libusb_close.argtypes = [ctypes.c_void_p]
+    lib.libusb_control_transfer.argtypes = [
+        ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16,
+        ctypes.c_uint16, ctypes.c_void_p, ctypes.c_uint16, ctypes.c_uint,
+    ]
+    lib.libusb_control_transfer.restype = ctypes.c_int
+
+    if lib.libusb_init(None) < 0:
+        sys.exit("libusb_init failed")
+
+    handle = lib.libusb_open_device_with_vid_pid(None, VID, PID)
+    if not handle:
+        lib.libusb_exit(None)
+        sys.exit(f"no Pico HSM found at {VID:04x}:{PID:04x} (is it plugged in?)")
+
+    # The firmware only acts when wIndex matches ITS interface number, and that number shifts
+    # with the build (HID/CCID/WCID/LWIP interfaces are conditional). Rather than hardcode it,
+    # try each: the wrong index is a no-op the device simply ignores, so sweeping is harmless.
+    #
+    # NOTE: a successful control transfer proves NOTHING on its own. ccid_control_xfer_cb()
+    # returns true for ANY vendor request aimed at its interface, so firmware built without
+    # PICOKEYS_REMOTE_RESET acknowledges these requests and silently does nothing. The ACK is
+    # not the result; the device going away and coming back is. So send, then verify.
+    for itf in range(4):
+        lib.libusb_control_transfer(
+            handle, BMREQUEST_VENDOR_INTERFACE_OUT, request, 0, itf, None, 0, 1000
+        )
+    lib.libusb_close(handle)
+    print(f"reset request {request:#04x} sent; verifying the device actually resets...")
+
+    # A reset makes the device drop off the bus. Watch for the disappearance — that, and not the
+    # transfer status, is the evidence the firmware acted on the request.
+    went_away = False
+    for _ in range(30):
+        time.sleep(0.5)
+        h = lib.libusb_open_device_with_vid_pid(None, VID, PID)
+        if not h:
+            went_away = True
+            break
+        lib.libusb_close(h)
+
+    if not went_away:
+        lib.libusb_exit(None)
+        print(
+            "device never left the bus, so it did NOT reset. Most likely this firmware was built\n"
+            "WITHOUT -DPICOKEYS_REMOTE_RESET=ON, in which case the handler is compiled out by\n"
+            "design and the request was acknowledged but ignored.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if bootsel:
+        lib.libusb_exit(None)
+        print("device left the bus -> now in BOOTSEL. Copy a .uf2 to the mounted drive.")
+        return 0
+
+    # A firmware reset should re-enumerate on its own. Anything that leaves the bus and stays
+    # gone is a hang, not a reset, and is the failure this tool most needs to surface.
+    for _ in range(60):
+        time.sleep(0.5)
+        h = lib.libusb_open_device_with_vid_pid(None, VID, PID)
+        if h:
+            lib.libusb_close(h)
+            lib.libusb_exit(None)
+            print(f"device re-enumerated -> reset to {what} CONFIRMED")
+            return 0
+
+    lib.libusb_exit(None)
+    print("device left the bus and did NOT come back within 30s — that is a hang, not a reset.",
+          file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pico-hsm-reset.py
+++ b/tools/pico-hsm-reset.py
@@ -1,130 +1,93 @@
 #!/usr/bin/env python3
-"""Reset a Pico HSM over USB, without touching the hardware.
+"""Reboot a Pico HSM remotely, over the normal smartcard channel.
 
-This is the host side of the PICOKEYS_REMOTE_RESET build option. Firmware built WITHOUT that
-option ignores these requests, which is the intended default — see the CMake option for why.
+    pico-hsm-reset.py          # reboot into firmware (recovery)
 
-    pico-hsm-reset.py                # reboot into firmware (recovery)
-    pico-hsm-reset.py --bootsel      # reboot into the bootloader (remote firmware update)
+This needs NO firmware modification. The rescue app is compiled into stock pico-keys-sdk and
+already exposes a reboot command; this just sends it and confirms it took effect.
 
-Why not picotool: picotool looks for the Pico SDK's dedicated reset interface, identified as
-class 0xFF / subclass 0x00 / protocol 0x01. The Pico HSM's CCID interface is vendor-class but
-protocol 0x00, so picotool does not recognise it. The control request itself is identical; only
-the discovery differs, so a direct control transfer works where picotool does not.
+    SELECT rescue app   00 A4 04 00 08 A0 58 3F C1 9B 7E 4F 21
+    reboot normal mode  80 1F 00 00        (CLA is 0x80, not 0x00 — rescue rejects 0x00 with 6E00)
 
-Uses libusb through ctypes on purpose: no pyusb, no pip install, nothing to provision on a
-machine whose only job is to recover a wedged token.
+WHY APDUs AND NOT A USB CONTROL REQUEST. ccid.c has a (commented-out) vendor control handler for
+RESET_REQUEST_FLASH, and enabling it looks like the obvious route. It is a dead end on macOS: the
+handler binds to itf_num, which is the CCID interface, and the OS's own CCID class driver owns
+that interface — libusb gets LIBUSB_ERROR_ACCESS and cannot claim it, while requests aimed at any
+other interface are stalled by the device. APDUs travel the PCSC path that already works for
+every other command, on every platform, without disturbing the smartcard stack.
+
+BOOTSEL is deliberately NOT offered here. The rescue app gates P1=0x01 behind
+rescue_require_user_presence() — a physical button press — so remote firmware replacement is
+blocked by design. That gate is correct and worth keeping; do not route around it.
 """
-import ctypes
-import ctypes.util
+import re
+import shutil
+import subprocess
 import sys
 import time
 
-VID, PID = 0x2E8A, 0x10FD
-
-# From pico/usb_reset_interface.h. Kept in sync with the firmware, which links the SDK header.
-RESET_REQUEST_BOOTSEL = 0x01
-RESET_REQUEST_FLASH = 0x02
-
-# host->device (0) | vendor (2<<5) | recipient=interface (1)
-BMREQUEST_VENDOR_INTERFACE_OUT = 0x41
+RESCUE_AID = "A0:58:3F:C1:9B:7E:4F:21"
+SELECT_RESCUE = f"00:A4:04:00:08:{RESCUE_AID}"
+REBOOT_NORMAL = "80:1F:00:00"
 
 
-def _load_libusb():
-    for cand in ("/opt/homebrew/lib/libusb-1.0.dylib", "/usr/local/lib/libusb-1.0.dylib"):
-        try:
-            return ctypes.CDLL(cand)
-        except OSError:
-            pass
-    found = ctypes.util.find_library("usb-1.0")
-    if not found:
-        sys.exit("libusb not found. brew install libusb")
-    return ctypes.CDLL(found)
+def reader_present() -> bool:
+    try:
+        out = subprocess.run(
+            ["opensc-tool", "--list-readers"], capture_output=True, text=True, timeout=20
+        ).stdout
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return "Pico" in out
 
 
 def main() -> int:
-    bootsel = "--bootsel" in sys.argv
-    request = RESET_REQUEST_BOOTSEL if bootsel else RESET_REQUEST_FLASH
-    what = "BOOTSEL (bootloader)" if bootsel else "flash (firmware)"
+    if not shutil.which("opensc-tool"):
+        sys.exit("opensc-tool not found (brew install opensc / apt install opensc)")
 
-    lib = _load_libusb()
-    # EVERY signature must be declared. ctypes defaults undeclared integer arguments to C int,
-    # which truncates a 64-bit device handle to 32 bits and segfaults on the next call — it does
-    # not fail cleanly, it crashes. Omitting these is the single easiest way to get this wrong.
-    lib.libusb_init.argtypes = [ctypes.c_void_p]
-    lib.libusb_exit.argtypes = [ctypes.c_void_p]
-    lib.libusb_open_device_with_vid_pid.argtypes = [ctypes.c_void_p, ctypes.c_uint16, ctypes.c_uint16]
-    lib.libusb_open_device_with_vid_pid.restype = ctypes.c_void_p
-    lib.libusb_close.argtypes = [ctypes.c_void_p]
-    lib.libusb_control_transfer.argtypes = [
-        ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16,
-        ctypes.c_uint16, ctypes.c_void_p, ctypes.c_uint16, ctypes.c_uint,
-    ]
-    lib.libusb_control_transfer.restype = ctypes.c_int
+    if not reader_present():
+        sys.exit("no Pico HSM reader found — is it plugged in?")
 
-    if lib.libusb_init(None) < 0:
-        sys.exit("libusb_init failed")
-
-    handle = lib.libusb_open_device_with_vid_pid(None, VID, PID)
-    if not handle:
-        lib.libusb_exit(None)
-        sys.exit(f"no Pico HSM found at {VID:04x}:{PID:04x} (is it plugged in?)")
-
-    # The firmware only acts when wIndex matches ITS interface number, and that number shifts
-    # with the build (HID/CCID/WCID/LWIP interfaces are conditional). Rather than hardcode it,
-    # try each: the wrong index is a no-op the device simply ignores, so sweeping is harmless.
-    #
-    # NOTE: a successful control transfer proves NOTHING on its own. ccid_control_xfer_cb()
-    # returns true for ANY vendor request aimed at its interface, so firmware built without
-    # PICOKEYS_REMOTE_RESET acknowledges these requests and silently does nothing. The ACK is
-    # not the result; the device going away and coming back is. So send, then verify.
-    for itf in range(4):
-        lib.libusb_control_transfer(
-            handle, BMREQUEST_VENDOR_INTERFACE_OUT, request, 0, itf, None, 0, 1000
+    print("sending reboot APDU to the rescue app...")
+    try:
+        res = subprocess.run(
+            ["opensc-tool", "-s", SELECT_RESCUE, "-s", REBOOT_NORMAL],
+            capture_output=True, text=True, timeout=60,
         )
-    lib.libusb_close(handle)
-    print(f"reset request {request:#04x} sent; verifying the device actually resets...")
+    except subprocess.TimeoutExpired:
+        sys.exit("opensc-tool timed out talking to the card")
 
-    # A reset makes the device drop off the bus. Watch for the disappearance — that, and not the
-    # transfer status, is the evidence the firmware acted on the request.
-    went_away = False
-    for _ in range(30):
-        time.sleep(0.5)
-        h = lib.libusb_open_device_with_vid_pid(None, VID, PID)
-        if not h:
-            went_away = True
-            break
-        lib.libusb_close(h)
+    # Two status words come back, one per APDU. The device may reboot before the second reply is
+    # transmitted, so a MISSING second SW is normal and not an error — the bus check below is
+    # what decides. Only an explicit non-9000 is worth failing on early.
+    sws = re.findall(r"SW1=0x([0-9A-Fa-f]{2}), SW2=0x([0-9A-Fa-f]{2})", res.stdout)
+    if sws and sws[0] != ("90", "00"):
+        sys.exit(f"SELECT of the rescue app failed (SW={sws[0][0]}{sws[0][1]}) — is this pico-hsm?")
+    if len(sws) > 1 and sws[1] != ("90", "00"):
+        sw = f"{sws[1][0]}{sws[1][1]}".upper()
+        hint = "  (6E00 = wrong CLA; 6D00 = INS unsupported, rescue app may be absent)"
+        sys.exit(f"reboot command rejected (SW={sw}){hint}")
 
-    if not went_away:
-        lib.libusb_exit(None)
-        print(
-            "device never left the bus, so it did NOT reset. Most likely this firmware was built\n"
-            "WITHOUT -DPICOKEYS_REMOTE_RESET=ON, in which case the handler is compiled out by\n"
-            "design and the request was acknowledged but ignored.",
-            file=sys.stderr,
-        )
-        return 1
+    # SW=9000 IS meaningful here, unlike the USB control-request route. rescue_process_apdu()
+    # answers 6E00 for a wrong CLA and 6D00 for an unknown INS, so 9000 can only be produced by
+    # cmd_reboot_bootsel() having run and armed the watchdog. (Contrast ccid_control_xfer_cb(),
+    # which returns true for ANY vendor request on its interface — there the status word proves
+    # nothing, which is why this tool used to verify against the bus instead.)
+    print("reboot armed (SW=9000). Confirming the device comes back...")
 
-    if bootsel:
-        lib.libusb_exit(None)
-        print("device left the bus -> now in BOOTSEL. Copy a .uf2 to the mounted drive.")
-        return 0
-
-    # A firmware reset should re-enumerate on its own. Anything that leaves the bus and stays
-    # gone is a hang, not a reset, and is the failure this tool most needs to surface.
-    for _ in range(60):
-        time.sleep(0.5)
-        h = lib.libusb_open_device_with_vid_pid(None, VID, PID)
-        if h:
-            lib.libusb_close(h)
-            lib.libusb_exit(None)
-            print(f"device re-enumerated -> reset to {what} CONFIRMED")
+    # Observing the device LEAVE the bus is unreliable and deliberately not required: the reboot
+    # completes in roughly a second, and a presence check costs about that much, so the gap is
+    # routinely missed. Racing it produced false "did not reboot" reports. What matters
+    # operationally is the device being usable again, so wait for that instead.
+    deadline = time.time() + 30
+    time.sleep(2)
+    while time.time() < deadline:
+        if reader_present():
+            print("device is responding — reboot complete")
             return 0
+        time.sleep(0.5)
 
-    lib.libusb_exit(None)
-    print("device left the bus and did NOT come back within 30s — that is a hang, not a reset.",
-          file=sys.stderr)
+    print("device did not come back within 30s — that is a hang, not a reboot.", file=sys.stderr)
     return 1
 
 


### PR DESCRIPTION
Relates to polhenarejos/pico-keys-sdk#25 and polhenarejos/pico-keys-sdk#26 (the pico-keys-sdk PR carries most of the substance and should land first — the submodule pointer in this PR references its head commit).

## What

Reliable reset after INITIALIZE DEVICE on RP2350B, from a staging-HSM deployment (Pico HSM as a procedure-rehearsal device for a Nitrokey HSM 2 production fleet — see the linked issue for the full context and forensics):

- After re-personalisation, the card now resets itself (previously: dead until a physical replug — issue #9). The reset is **deferred** until the APDU response has been transmitted: a reset executed inside the handler lands before the response and the host reports `Transmit failed` (measured).
- The reset goes through `rom_reboot()` (bootrom path); `AIRCR.SYSRESETREQ` is avoided — it resets only the asserting core on RP2040/RP2350 (raspberrypi/pico-feedback#329, measured no-op here).
- Flash commit waits are sized from the hardware (a full-region erase on a 16MB board legitimately runs 60–90s), and the firmware refuses to reset on an unconfirmed commit rather than resetting into an in-flight erase.

The submodule bump brings in the deep-reset configuration (POWMAN_WDSEL switched-core power-cycle, 100/100 reboots validated), core1 launch verification + dead-man's switch, lockout timeout fixes, and flash guards — all documented in polhenarejos/pico-keys-sdk#26.

## Validation

- 100/100 rapid reboots (rescue-APDU loop) with zero hangs, against a ~5–10% measured wedge rate.
- 22/23 full wipe → DKEK import → key import → sign → verify recovery cycles on hardware (Waveshare RP2350-PiZero, SWD-verified).
