### PR TITLE
fix(hsm): make the bootstrap device name device-unique, not a shared constant

### DIFF
--- a/src/hsm/sc_hsm.c
+++ b/src/hsm/sc_hsm.c
@@ -205,6 +205,30 @@ int puk_store_select_chr(const uint8_t *chr) {
     return PICOKEYS_ERR_FILE_NOT_FOUND;
 }
 
+/* Device name used when the card has no usable EF.C_DevAut yet.
+ *
+ * Layout is the conventional CVC holder reference: an 11-character holder id followed by a
+ * 5-digit sequence number, 16 total. OpenSC derives the PKCS#11 token serial from this CHR by
+ * stripping the last five characters unconditionally (pkcs15-sc-hsm.c, "Strip last 5 digit
+ * sequence number from CHR"), so all of the uniqueness has to live in the leading 11 — hence
+ * "ESP" plus 32 bits of the board serial. That keeps the established "ESP..." prefix
+ * recognisable to operators while making the derived token serial distinct per device.
+ *
+ * pico_serial is filled by serial_init() on every supported platform, including ESP32, and
+ * PICO_UNIQUE_BOARD_ID_SIZE_BYTES is 8 or 16 there, so the last four bytes always exist. */
+#define BOOTSTRAP_DEV_NAME_LEN 16
+static uint8_t bootstrap_dev_name[BOOTSTRAP_DEV_NAME_LEN + 1];
+
+const uint8_t *hsm_bootstrap_dev_name(uint16_t *len) {
+    const uint8_t *sn = pico_serial.id + (PICO_UNIQUE_BOARD_ID_SIZE_BYTES - 4);
+    snprintf((char *) bootstrap_dev_name, sizeof(bootstrap_dev_name),
+             "ESP%02X%02X%02X%02X00001", sn[0], sn[1], sn[2], sn[3]);
+    if (len) {
+        *len = BOOTSTRAP_DEV_NAME_LEN;
+    }
+    return bootstrap_dev_name;
+}
+
 void reset_puk_store(void) {
     if (puk_store_entries > 0) { /* From previous session */
         for (int i = 0; i < puk_store_entries; i++) {
@@ -237,8 +261,7 @@ void reset_puk_store(void) {
         dev_name = cvc_get_chr(file_get_data(fterm), file_get_size(fterm), &dev_name_len);
     }
     if (!dev_name) {
-        dev_name = (const uint8_t *) "ESPICOHSMTR00001";
-        dev_name_len = (uint16_t)(strlen((const char *)dev_name));
+        dev_name = hsm_bootstrap_dev_name(&dev_name_len);
     }
     memset(puk_status, 0, sizeof(puk_status));
 }

--- a/src/hsm/sc_hsm.h
+++ b/src/hsm/sc_hsm.h
@@ -121,6 +121,9 @@ extern uint16_t check_pin(const file_t *pin, const_byte_array_t data);
 extern bool pka_enabled(void);
 extern const uint8_t *dev_name;
 extern uint16_t dev_name_len;
+/* Deterministic, device-unique device name used when the card has no usable EF.C_DevAut.
+ * See hsm_bootstrap_dev_name() in sc_hsm.c. */
+extern const uint8_t *hsm_bootstrap_dev_name(uint16_t *len);
 extern uint8_t puk_status[MAX_PUK];
 extern int puk_store_select_chr(const uint8_t *chr);
 extern const_byte_array_t get_meta_tag(file_t *ef, uint16_t meta_tag);


### PR DESCRIPTION
**Rebased onto master and cut down to one value change.** The deadlock this PR originally fixed is
now fixed by your 49616b4 — that part is yours and I have dropped it. What is left is the fallback
CHR itself.

## The change

`reset_puk_store()` keeps exactly the control flow 49616b4 introduced. Only the value changes:

```c
 if (!dev_name) {
-    dev_name = (const uint8_t *) "ESPICOHSMTR00001";
-    dev_name_len = (uint16_t)(strlen((const char *)dev_name));
+    dev_name = hsm_bootstrap_dev_name(&dev_name_len);
 }
```

where `hsm_bootstrap_dev_name()` formats `"ESP%02X%02X%02X%02X00001"` from the last four bytes of
the board serial.

## Why the value matters

The fallback is not a transient placeholder — it becomes the card's permanent identity:

1. `init_sc_hsm()` calls `reset_puk_store()` at boot, so on a card with no `EF.C_DevAut`,
   `dev_name` is already the fallback before any command runs;
2. `INITIALIZE` builds the device certificate with that CHR and stores it in `EF_TERMCA`
   (`cmd_initialize.c`, `asn1_cvc_cert` then `file_put_data`);
3. every subsequent boot reads `dev_name` back out of that certificate.

So whatever the fallback is on first provisioning, the card keeps forever.

OpenSC derives the PKCS#11 token serial from that CHR by stripping the last five characters
unconditionally — [`src/libopensc/pkcs15-sc-hsm.c:1448`](https://github.com/OpenSC/OpenSC/blob/master/src/libopensc/pkcs15-sc-hsm.c#L1448):

```c
len = strnlen(devcert.chr, sizeof devcert.chr);  /* Strip last 5 digit sequence number from CHR */
if (len < 8)
    return SC_ERROR_INTERNAL;
len -= 5;
```

With a fixed `ESPICOHSMTR00001`, every device provisioned from a blank filesystem reports
`token serial = ESPICOHSMTR`. Identically, and permanently. Two such cards on one host cannot be
distinguished by the field PKCS#11 tooling uses to select a token.

With this change the same card reports a serial derived from its own board id — on my bench,
CHR `ESP2202E14A00001` -> `serial num : ESP2202E14A`, read back through `pkcs11-tool`.

## Portability

`pico_serial` is filled by `serial_init()` on every supported platform including ESP32
(`serial.c` has an `ESP_PLATFORM` branch), and `PICO_UNIQUE_BOARD_ID_SIZE_BYTES` is 8 or 16, so the
last four bytes always exist. The 11+5 CVC holder-reference layout is preserved, as is the
recognisable `ESP` prefix.

## Verification

Compile-checked on this rebase: `PICO_BOARD=waveshare_rp2350_pizero`, arm-gnu-15.2 — clean,
0 warnings. `strings` on the resulting ELF shows the new format string present.

Hardware evidence for the mechanism (device-unique CHR surviving provisioning, wrap/unwrap round
trip, RRC posture) is from RP2350B, on this one board. I have no ESP32 hardware, so the ESP32
claim above is source-level only.

## Not included, deliberately

`cvc.c:43` still carries `car = dev_name ? dev_name : "ESPICOHSMTR00001";`. As far as I can tell
that branch is now unreachable — `reset_puk_store()` guarantees `dev_name` is non-NULL before any
command runs — so I left it alone to keep this diff to one value. Say the word and I will fold in
its removal, or leave it as the belt-and-braces it now is.

`cmd_initialize.c:255`'s `"ESPICOHSMTR"` is a PRKD *label*, not a CHR, and is untouched.
