### PR TITLE
fix(hsm): reset the output buffer before building C.DevAut (EF 2F02 holds an extra object)

### DIFF
--- a/src/hsm/cmd_initialize.c
+++ b/src/hsm/cmd_initialize.c
@@ -239,6 +239,14 @@ int cmd_initialize(void) {
                 return SW_EXEC_ERROR();
             }
 
+            /* Reset the output buffer before building the device certificate. asn1_cvc_*
+             * APPEND (output->len += out_len), so without this EF_TERMCA is written with
+             * the CUMULATIVE length and ends up holding the EE authenticated request
+             * (tag 0x67) followed by the certificate (tag 7F21) — 940 bytes instead of
+             * 443. OpenSC then decodes the request as the device certificate. The EE
+             * request has already been copied into the flash page cache by file_put_data
+             * above, so reusing the buffer here is safe. */
+            certificates.len = 0;
             if (asn1_cvc_cert(&subject_pk, &certificates, CONST_BYTE_ARRAY(NULL, 0), true) == 0) {
                 mbedtls_ecdsa_free(&ecdsa);
                 return SW_EXEC_ERROR();

--- a/src/hsm/cmd_initialize.c
+++ b/src/hsm/cmd_initialize.c
@@ -239,14 +239,7 @@ int cmd_initialize(void) {
                 return SW_EXEC_ERROR();
             }
 
-            /* Reset the output buffer before building the device certificate. asn1_cvc_*
-             * APPEND (output->len += out_len), so without this EF_TERMCA is written with
-             * the CUMULATIVE length and ends up holding the EE authenticated request
-             * (tag 0x67) followed by the certificate (tag 7F21) — 940 bytes instead of
-             * 443. OpenSC then decodes the request as the device certificate. The EE
-             * request has already been copied into the flash page cache by file_put_data
-             * above, so reusing the buffer here is safe. */
-            certificates.len = 0;
+            certificates.len = 0; // Reset output buffer
             if (asn1_cvc_cert(&subject_pk, &certificates, CONST_BYTE_ARRAY(NULL, 0), true) == 0) {
                 mbedtls_ecdsa_free(&ecdsa);
                 return SW_EXEC_ERROR();


### PR DESCRIPTION
`EF_TERMCA` (C.DevAut, EF `2F02`) is written with the wrong length, so it contains an extra
certificate object it should not.

## The bug

`asn1_cvc_aut()` and `asn1_cvc_cert()` both **append** to the output buffer
(`output->len += out_len` in `src/hsm/cvc.c`). In `cmd_initialize` the same `certificates` buffer
is used for both, and is never reset in between:

```c
byte_buffer_t certificates = BYTE_BUFFER(res_APDU, MAX_APDU_DATA);

asn1_cvc_aut(&subject_pk, &certificates, ...);      /* -> certificates.len = 497 */
ee_len = (uint16_t)certificates.len;
file_put_data(file_search(EF_EE_DEV), CONST_BYTE_ARRAY(res_APDU, ee_len));       /* correct */

asn1_cvc_cert(&subject_pk, &certificates, ..., true);  /* APPENDS -> len = 940  */
file_put_data(file_search(EF_TERMCA), CONST_BYTE_ARRAY(res_APDU, certificates.len));
                                                    /* writes BOTH objects      */
```

So C.DevAut ends up holding the EE authenticated request followed by the device certificate.
Walking the TLVs of EF 2F02 read off a card:

```
total 940 bytes
  object 0: tag=67    length=493  total=497   <- EE authenticated request (identical to EF_EE_DEV)
  object 1: tag=7F21  length=438  total=443   <- the device certificate
```

## Why it matters

OpenSC decodes the **first** object as the device certificate
(`sc_pkcs15emu_sc_hsm_decode_cvc`, `pkcs15-sc-hsm.c`), so what it treats as C.DevAut is actually
the EE *request*. It happens to yield a usable CHR, so the failure is silent — but any consumer
doing a strict TR-03110 decode of EF 2F02 sees a `0x67` where a `7F21` belongs. Our offline
verifier rejects it outright ("not a parseable CVC certificate").

## The fix

Reset the buffer before building the certificate. The EE request has already been copied into the
flash page cache by `file_put_data` above, so reusing the buffer is safe.

## Measured

On an RP2350B, full 16 MB erase then a single INITIALIZE:

| | EF 2F02 |
|---|---|
| before | 940 bytes (`0x67` + `7F21`) |
| after | **443 bytes** (`7F21` only) |

`EF_EE_DEV` is unchanged at 497 bytes. Our staging identity check goes from FAIL to PASS with
`CHR=ESP2202E14A00001 CAR=ESP2202E14A00001`, and the full battery is green.

Independent of, and complementary to, #137 (which fixes C.DevAut never being created at all).

Hardware scope: one Waveshare RP2350-PiZero with a Raspberry Pi Debug Probe. No RP2040 hardware,
so no runtime claim for RP2040.
