### PR TITLE
Fix INITIALIZE failing with SW 6400 on first attempt (missing default CHR fallback)

### DIFF
--- a/src/hsm/cvc.c
+++ b/src/hsm/cvc.c
@@ -137,7 +137,14 @@ uint16_t asn1_cvc_aut(const mbedtls_pk_context *subject, byte_buffer_t *output, 
     uint16_t cert_len, request_len, out_len = 0;
     size_t outer_sig_len;
     uint8_t placeholder = 0;
-    if (!output || output->len > output->capacity || output->capacity - output->len > UINT16_MAX || extension.len > UINT16_MAX || !subject || !fkey || !dev_name || !dev_name_len) {
+    static const uint8_t default_chr[] = "ESPICOHSMTR00001";
+    const uint8_t *outer_car = dev_name;
+    uint16_t outer_car_len = dev_name_len;
+    if (!outer_car || !outer_car_len) {
+        outer_car = default_chr;
+        outer_car_len = (uint16_t)(sizeof(default_chr) - 1);
+    }
+    if (!output || output->len > output->capacity || output->capacity - output->len > UINT16_MAX || extension.len > UINT16_MAX || !subject || !fkey) {
         return 0;
     }
     uint8_t *buf = output->data ? output->data + output->len : NULL;
@@ -152,11 +159,11 @@ uint16_t asn1_cvc_aut(const mbedtls_pk_context *subject, byte_buffer_t *output, 
         return 0;
     }
     cvc_write_req_init(&ctx);
-    if (cvc_configure_cert(&ctx.cert, subject, false, extension) != 0 || dev_name_len > sizeof(ctx.outer_car_buf)) {
+    if (cvc_configure_cert(&ctx.cert, subject, false, extension) != 0 || outer_car_len > sizeof(ctx.outer_car_buf)) {
         mbedtls_ecp_keypair_free(&device_key);
         return 0;
     }
-    if (cvc_req_set_outer_signing_key(&ctx, &outer) != LIBCVC_OK || cvc_req_set_outer_car(&ctx, dev_name, dev_name_len) != LIBCVC_OK) {
+    if (cvc_req_set_outer_signing_key(&ctx, &outer) != LIBCVC_OK || cvc_req_set_outer_car(&ctx, outer_car, outer_car_len) != LIBCVC_OK) {
         mbedtls_ecp_keypair_free(&device_key);
         return 0;
     }


### PR DESCRIPTION
# Pico HSM: INITIALIZE fails with SW 6400 ("Card command failed") on first attempt

## Summary

`sc-hsm-tool --initialize` (INS 0x50) fails on the first attempt with
`SW 6400` (execution error, shown by OpenSC as "Card command failed")
whenever the PIN/SO-PIN differ from the currently stored ones, or on a
freshly flashed device. Re-running the identical command succeeds. The
failure is caused by a regression in `asn1_cvc_aut()`: the default
device-name (CHR) fallback was lost in the libcvc refactor.

## Symptom

```
$ sc-hsm-tool --initialize --so-pin XXX --pin XXX
Using reader with a card: Nitrokey Nitrokey HSM [...] 00 00
sc_card_ctl(*, SC_CARDCTL_SC_HSM_INITIALIZE, *) failed with Card command failed

$ sc-hsm-tool --initialize --so-pin XXX --pin XXX   # same command again
Using reader with a card: Nitrokey Nitrokey HSM [...] 00 00
(no error - succeeds)
```

Reproduced on ESP32-S3 (firmware 6.6, ESP-IDF v5.5). The code path is
shared with Pico builds; the same regression affects a fresh device on
any platform.

## Root cause

`cmd_initialize()` in `src/hsm/cmd_initialize.c`:

1. `file_initialize_flash(true)` + `scan_all()` reset the in-RAM file
   state, including `EF_TERMCA` (the device certificate), without
   re-deriving the global `dev_name` (set only by `reset_puk_store()`,
   which runs *after* certificate generation).
2. When the MKEK must be re-created (PIN/SO-PIN changed or first
   initialization), the code regenerates the device key and builds its
   C.DevAut certificate with `asn1_cvc_aut()`.
3. `asn1_cvc_aut()` requires `dev_name` (the CHR read from EF_TERMCA)
   as the certificate's outer CAR. On a fresh card EF_TERMCA is empty,
   so `dev_name == NULL` and the function returns 0, which
   `cmd_initialize()` maps to `SW_EXEC_ERROR` (0x6400).

Before the libcvc refactor (commit 5a8a27f), `asn1_cvc_aut` fell back
to the default CHR `"ESPICOHSMTR00001"` when `dev_name` was NULL (see
the pre-refactor code in 2a5fe1c). The refactor replaced that fallback
with a hard `!dev_name` bail-out.

The retry "succeeds" only because the failed attempt already stored
the new PINs, MKEK and device key; the retry therefore takes the fast
path (MKEK loads, device key loads) and skips certificate generation
entirely - leaving `EF_EE_DEV`/`EF_TERMCA` empty and the card without
a usable device certificate.

## Diagnosis method

- APDU-level reproduction with pyscard/opensc-tool: INITIALIZE with
  changed PINs -> SW 6400 on first attempt, SW 9000 on retry; file
  probe showed `EF_EE_DEV`/`EF_TERMCA` empty.
- Instrumented firmware: unique SW per failure path
  (`0x64A1`-`0x64AD`, `0x64B0`-`0x64B9` in cmd_initialize/kek, and a
  `dbg_cvc` stage code 0x64E0+ in `asn1_cvc_aut`). The failing return
  was `0x64E2` = `!dev_name` inside `asn1_cvc_aut()`.

## Fix

`src/hsm/cvc.c` - `asn1_cvc_aut()`: restore the default device-name
fallback as the outer CAR when `dev_name` is NULL or empty, matching
the existing fallback in `cvc_configure_cert()`:

```c
static const uint8_t default_chr[] = "ESPICOHSMTR00001";
const uint8_t *outer_car = dev_name;
uint16_t outer_car_len = dev_name_len;
if (!outer_car || !outer_car_len) {
    outer_car = default_chr;
    outer_car_len = (uint16_t)(sizeof(default_chr) - 1);
}
```

## Verification

With the fix (ESP32-S3, firmware 6.6):

- INITIALIZE with new PIN/SO-PIN succeeds on the FIRST attempt
  (SW 9000).
- `EF_EE_DEV` (256 bytes) and `EF_TERMCA` (256 bytes, CHR
  `ESPICOHSMTR00001`) are written correctly.
- `sc-hsm-tool --initialize` works end-to-end on the first run.
- The device certificate chain (C.DevAut / EF_TERMCA / PRKD) is
  present, satisfying the `test_termca` expectations in the test
  suite.

## Related upstream findings (out of scope of this commit)

Observed while building for ESP32-S3 (these belong to the
pico-keys-sdk repository):

1. The ESP32 components register unconditionally but the third-party
   sources (cjson, tinycbor, mlkem, mldsa) are only fetched when the
   corresponding feature flags are enabled; a default `idf.py`
   configure fails with "Include directory ... is not a directory".
2. `espressif/esp_tinyusb: "^1.7.6"` currently resolves `espressif/tinyusb`
   0.21.0, whose `usbd_edpt_xfer()` gained an `is_isr` parameter;
   `ccid.c` no longer compiles. Pinning `espressif/tinyusb: "=0.19.0~3"`
   fixes the build.